### PR TITLE
feat: add matchmaking activity pages for wedding reception

### DIFF
--- a/apps/backend/src/db/migrations/0001_matchmaking_submissions.sql
+++ b/apps/backend/src/db/migrations/0001_matchmaking_submissions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "matchmaking_submissions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"submitter_name" text NOT NULL,
+	"friend_name" text NOT NULL,
+	"contact" text NOT NULL,
+	"bio" text,
+	"photo_base64" text,
+	"approved" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/backend/src/db/migrations/meta/0001_snapshot.json
+++ b/apps/backend/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,133 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef0123456789",
+  "prevId": "ff93ff8d-b8e1-4e37-9a2e-ecb9fef8aecb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.rsvps": {
+      "name": "rsvps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attending": {
+          "name": "attending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guests": {
+          "name": "guests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchmaking_submissions": {
+      "name": "matchmaking_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_name": {
+          "name": "friend_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_base64": {
+          "name": "photo_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1759593530866,
       "tag": "0000_far_giant_man",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1761177600000,
+      "tag": "0001_matchmaking_submissions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -12,3 +12,17 @@ export const rsvps = pgTable('rsvps', {
 
 export type InsertRsvp = typeof rsvps.$inferInsert;
 export type SelectRsvp = typeof rsvps.$inferSelect;
+
+export const matchmakingSubmissions = pgTable('matchmaking_submissions', {
+  id: serial('id').primaryKey(),
+  submitterName: text('submitter_name').notNull(),
+  friendName: text('friend_name').notNull(),
+  contact: text('contact').notNull(),
+  bio: text('bio'),
+  photoBase64: text('photo_base64'),
+  approved: boolean('approved').notNull().default(true),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type InsertMatchmakingSubmission = typeof matchmakingSubmissions.$inferInsert;
+export type SelectMatchmakingSubmission = typeof matchmakingSubmissions.$inferSelect;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -78,6 +78,131 @@ const app = new Elysia()
       return { success: false, message: 'Failed to fetch RSVPs' };
     }
   })
+  // Reject photo payloads larger than ~1.5MB of raw bytes (base64 adds ~33% overhead).
+  .post('/api/matchmaking', async ({ body, set }) => {
+    if (body.photoBase64 && body.photoBase64.length > 2_200_000) {
+      set.status = 413;
+      return { success: false, message: 'Photo too large. Please pick a smaller image.' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const rows = yield* sql<{
+            id: number;
+            submitter_name: string;
+            friend_name: string;
+            contact: string;
+            bio: string | null;
+            photo_base64: string | null;
+            approved: boolean;
+            created_at: string;
+          }>`
+            insert into matchmaking_submissions (submitter_name, friend_name, contact, bio, photo_base64)
+            values (${body.submitterName}, ${body.friendName}, ${body.contact}, ${body.bio ?? null}, ${body.photoBase64 ?? null})
+            returning id, submitter_name, friend_name, contact, bio, photo_base64, approved, created_at
+          `;
+          return rows[0];
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true, submission: result };
+    } catch (error) {
+      console.error('Failed to save matchmaking submission', error);
+      return { success: false, message: 'Failed to save submission' };
+    }
+  }, {
+    body: t.Object({
+      submitterName: t.String({ minLength: 1, maxLength: 120 }),
+      friendName: t.String({ minLength: 1, maxLength: 120 }),
+      contact: t.String({ minLength: 1, maxLength: 200 }),
+      bio: t.Optional(t.String({ maxLength: 500 })),
+      photoBase64: t.Optional(t.String())
+    })
+  })
+  .get('/api/matchmaking', async () => {
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const list = yield* sql<{
+            id: number; submitter_name: string; friend_name: string; contact: string; bio: string | null; photo_base64: string | null; approved: boolean; created_at: string;
+          }>`
+            select id, submitter_name, friend_name, contact, bio, photo_base64, approved, created_at
+            from matchmaking_submissions
+            where approved = true
+            order by created_at desc
+          `;
+          return list;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true, submissions: rows };
+    } catch (error) {
+      console.error('Failed to fetch matchmaking submissions', error);
+      return { success: false, message: 'Failed to fetch submissions' };
+    }
+  })
+  .get('/api/matchmaking/all', async ({ headers, set }) => {
+    const token = process.env.MATCHMAKING_MOD_TOKEN;
+    if (!token || headers['x-mod-token'] !== token) {
+      set.status = 401;
+      return { success: false, message: 'Unauthorized' };
+    }
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const list = yield* sql<{
+            id: number; submitter_name: string; friend_name: string; contact: string; bio: string | null; photo_base64: string | null; approved: boolean; created_at: string;
+          }>`
+            select id, submitter_name, friend_name, contact, bio, photo_base64, approved, created_at
+            from matchmaking_submissions
+            order by created_at desc
+          `;
+          return list;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true, submissions: rows };
+    } catch (error) {
+      console.error('Failed to fetch all matchmaking submissions', error);
+      return { success: false, message: 'Failed to fetch submissions' };
+    }
+  })
+  .patch('/api/matchmaking/:id', async ({ params, body, headers, set }) => {
+    const token = process.env.MATCHMAKING_MOD_TOKEN;
+    if (!token || headers['x-mod-token'] !== token) {
+      set.status = 401;
+      return { success: false, message: 'Unauthorized' };
+    }
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      set.status = 400;
+      return { success: false, message: 'Invalid id' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const rows = yield* sql<{ id: number; approved: boolean }>`
+            update matchmaking_submissions
+            set approved = ${body.approved}
+            where id = ${id}
+            returning id, approved
+          `;
+          return rows[0];
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      if (!result) {
+        set.status = 404;
+        return { success: false, message: 'Not found' };
+      }
+      return { success: true, submission: result };
+    } catch (error) {
+      console.error('Failed to update matchmaking submission', error);
+      return { success: false, message: 'Failed to update submission' };
+    }
+  }, {
+    body: t.Object({ approved: t.Boolean() })
+  })
   .listen(3000);
 
 // Run a connectivity check on startup and log the result

--- a/apps/frontend/src/router/index.ts
+++ b/apps/frontend/src/router/index.ts
@@ -45,6 +45,21 @@ const router = createRouter({
       name: 'gallery',
       component: () => import('../views/GalleryView.vue'),
     },
+    {
+      path: '/matchmaking',
+      name: 'matchmaking',
+      component: () => import('../views/MatchmakingView.vue'),
+    },
+    {
+      path: '/matchmaking/board',
+      name: 'matchmaking-board',
+      component: () => import('../views/MatchmakingBoardView.vue'),
+    },
+    {
+      path: '/matchmaking/moderate',
+      name: 'matchmaking-moderate',
+      component: () => import('../views/MatchmakingModerateView.vue'),
+    },
     // todo add video presentation
     // todo pre wedding photo
     // todo seat plan

--- a/apps/frontend/src/views/MatchmakingBoardView.vue
+++ b/apps/frontend/src/views/MatchmakingBoardView.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+
+type Submission = {
+  id: number
+  submitter_name: string
+  friend_name: string
+  contact: string
+  bio: string | null
+  photo_base64: string | null
+  approved: boolean
+  created_at: string
+}
+
+const submissions = ref<Submission[]>([])
+const error = ref<string | null>(null)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+async function load() {
+  try {
+    const res = await fetch('/api/matchmaking')
+    const data = await res.json()
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to load')
+    submissions.value = data.submissions as Submission[]
+    error.value = null
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to load'
+  }
+}
+
+onMounted(() => {
+  load()
+  pollTimer = setInterval(load, 5000)
+})
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+})
+</script>
+
+<template>
+  <main class="min-h-screen bg-gradient-to-br from-rose-50 via-white to-rose-100 px-6 py-8">
+    <header class="mb-8 text-center">
+      <p class="text-sm uppercase tracking-[0.3em] text-rose-600">Kaywalee &amp; Supanat · Wedding Activity</p>
+      <h1 class="font-cookie mt-2 text-6xl sm:text-7xl text-rose-600">Matchmaking Corner</h1>
+      <p class="mt-2 text-gray-600">Meet our lovely single friends — say hi tonight!</p>
+    </header>
+
+    <p v-if="error" class="mb-4 text-center text-rose-700">{{ error }}</p>
+
+    <div
+      v-if="submissions.length === 0 && !error"
+      class="flex min-h-[50vh] flex-col items-center justify-center text-center"
+    >
+      <p class="font-cookie text-4xl text-rose-500">Submissions will appear here</p>
+      <p class="mt-2 text-gray-500">Scan the QR code to be the first to share a friend.</p>
+    </div>
+
+    <section
+      class="grid gap-6"
+      style="grid-template-columns: repeat(auto-fill, minmax(260px, 1fr))"
+    >
+      <article
+        v-for="entry in submissions"
+        :key="entry.id"
+        class="flex flex-col overflow-hidden rounded-3xl border border-rose-100 bg-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl"
+      >
+        <div class="aspect-[4/5] w-full bg-rose-50">
+          <img
+            v-if="entry.photo_base64"
+            :src="entry.photo_base64"
+            :alt="entry.friend_name"
+            class="h-full w-full object-cover"
+          />
+          <div
+            v-else
+            class="flex h-full w-full items-center justify-center font-cookie text-6xl text-rose-400"
+          >
+            {{ entry.friend_name.charAt(0).toUpperCase() }}
+          </div>
+        </div>
+        <div class="flex flex-1 flex-col gap-2 p-4">
+          <h2 class="font-cookie text-3xl leading-tight text-rose-600">{{ entry.friend_name }}</h2>
+          <p v-if="entry.bio" class="text-sm text-gray-700">{{ entry.bio }}</p>
+          <p class="mt-auto text-sm font-semibold text-rose-700 break-words">{{ entry.contact }}</p>
+          <p class="text-xs text-gray-500">Submitted by {{ entry.submitter_name }}</p>
+        </div>
+      </article>
+    </section>
+  </main>
+</template>

--- a/apps/frontend/src/views/MatchmakingModerateView.vue
+++ b/apps/frontend/src/views/MatchmakingModerateView.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+type Submission = {
+  id: number
+  submitter_name: string
+  friend_name: string
+  contact: string
+  bio: string | null
+  photo_base64: string | null
+  approved: boolean
+  created_at: string
+}
+
+// Token kept in memory only so a shared device won't leak it — re-enter on reload.
+const token = ref('')
+const authed = ref(false)
+const loading = ref(false)
+const error = ref<string | null>(null)
+const submissions = ref<Submission[]>([])
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await fetch('/api/matchmaking/all', {
+      headers: { 'x-mod-token': token.value },
+    })
+    const data = await res.json().catch(() => ({}))
+    if (res.status === 401) {
+      error.value = 'Invalid moderator token.'
+      authed.value = false
+      return
+    }
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to load')
+    submissions.value = data.submissions as Submission[]
+    authed.value = true
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to load'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function setApproved(id: number, approved: boolean) {
+  try {
+    const res = await fetch(`/api/matchmaking/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'x-mod-token': token.value },
+      body: JSON.stringify({ approved }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to update')
+    const entry = submissions.value.find((s) => s.id === id)
+    if (entry) entry.approved = approved
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to update'
+  }
+}
+</script>
+
+<template>
+  <main class="min-h-screen bg-off-white px-4 py-10">
+    <section class="mx-auto max-w-4xl">
+      <h1 class="font-cookie text-5xl text-rose-600">Matchmaking Moderation</h1>
+      <p class="mt-2 text-gray-600">Take down submissions before they show on the big screen.</p>
+
+      <form v-if="!authed" class="mt-6 flex gap-3" @submit.prevent="load">
+        <input
+          v-model="token"
+          type="password"
+          required
+          placeholder="Moderator token"
+          class="w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+        />
+        <button
+          type="submit"
+          :disabled="loading"
+          class="rounded-full bg-rose-600 px-6 py-2.5 text-white hover:bg-rose-700 disabled:opacity-50"
+        >
+          {{ loading ? 'Loading…' : 'Enter' }}
+        </button>
+      </form>
+
+      <p v-if="error" class="mt-4 text-rose-700">{{ error }}</p>
+
+      <div v-if="authed" class="mt-8 space-y-4">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-gray-500">{{ submissions.length }} total · {{ submissions.filter((s) => s.approved).length }} showing on screen</p>
+          <button
+            class="text-sm text-rose-700 hover:underline"
+            @click="load"
+          >
+            Refresh
+          </button>
+        </div>
+
+        <article
+          v-for="entry in submissions"
+          :key="entry.id"
+          class="flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:flex-row"
+          :class="!entry.approved ? 'opacity-60' : ''"
+        >
+          <div class="w-full flex-shrink-0 sm:w-32">
+            <img
+              v-if="entry.photo_base64"
+              :src="entry.photo_base64"
+              :alt="entry.friend_name"
+              class="h-32 w-full rounded-lg object-cover sm:w-32"
+            />
+            <div
+              v-else
+              class="flex h-32 w-full items-center justify-center rounded-lg bg-rose-50 font-cookie text-4xl text-rose-400 sm:w-32"
+            >
+              {{ entry.friend_name.charAt(0).toUpperCase() }}
+            </div>
+          </div>
+
+          <div class="flex-1">
+            <h2 class="font-cookie text-3xl text-rose-600">{{ entry.friend_name }}</h2>
+            <p v-if="entry.bio" class="mt-1 text-sm text-gray-700">{{ entry.bio }}</p>
+            <p class="mt-2 text-sm text-gray-700"><strong>Contact:</strong> {{ entry.contact }}</p>
+            <p class="text-xs text-gray-500">Submitted by {{ entry.submitter_name }} · {{ new Date(entry.created_at).toLocaleString() }}</p>
+          </div>
+
+          <div class="flex items-start">
+            <button
+              v-if="entry.approved"
+              class="rounded-full bg-rose-50 px-4 py-2 text-sm text-rose-700 hover:bg-rose-100"
+              @click="setApproved(entry.id, false)"
+            >
+              Take down
+            </button>
+            <button
+              v-else
+              class="rounded-full bg-green-50 px-4 py-2 text-sm text-green-700 hover:bg-green-100"
+              @click="setApproved(entry.id, true)"
+            >
+              Restore
+            </button>
+          </div>
+        </article>
+
+        <p v-if="submissions.length === 0" class="text-center text-gray-500">No submissions yet.</p>
+      </div>
+    </section>
+  </main>
+</template>

--- a/apps/frontend/src/views/MatchmakingView.vue
+++ b/apps/frontend/src/views/MatchmakingView.vue
@@ -1,0 +1,208 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const submitterName = ref('')
+const friendName = ref('')
+const contact = ref('')
+const bio = ref('')
+const photoBase64 = ref<string | null>(null)
+const photoPreview = ref<string | null>(null)
+const loading = ref(false)
+const successMessage = ref<string | null>(null)
+const errorMessage = ref<string | null>(null)
+
+// Downscale an image file to a JPEG data URL so payloads stay small enough to store as base64 in Postgres.
+async function fileToDownscaledBase64(file: File, maxSize = 900, quality = 0.82): Promise<string> {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error('Could not read file'))
+    reader.readAsDataURL(file)
+  })
+
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Could not decode image'))
+    image.src = dataUrl
+  })
+
+  const ratio = Math.min(1, maxSize / Math.max(img.width, img.height))
+  const width = Math.round(img.width * ratio)
+  const height = Math.round(img.height * ratio)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas unavailable')
+  ctx.drawImage(img, 0, 0, width, height)
+  return canvas.toDataURL('image/jpeg', quality)
+}
+
+async function onFileChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  if (!file.type.startsWith('image/')) {
+    errorMessage.value = 'Please select an image file.'
+    return
+  }
+  try {
+    const compressed = await fileToDownscaledBase64(file)
+    photoBase64.value = compressed
+    photoPreview.value = compressed
+    errorMessage.value = null
+  } catch (err) {
+    console.error(err)
+    errorMessage.value = 'Could not read that image. Try another one.'
+  }
+}
+
+function clearPhoto() {
+  photoBase64.value = null
+  photoPreview.value = null
+}
+
+function resetForm() {
+  submitterName.value = ''
+  friendName.value = ''
+  contact.value = ''
+  bio.value = ''
+  clearPhoto()
+}
+
+async function submit() {
+  successMessage.value = null
+  errorMessage.value = null
+  loading.value = true
+  try {
+    const res = await fetch('/api/matchmaking', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        submitterName: submitterName.value.trim(),
+        friendName: friendName.value.trim(),
+        contact: contact.value.trim(),
+        bio: bio.value.trim() || undefined,
+        photoBase64: photoBase64.value ?? undefined,
+      }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) {
+      throw new Error(data?.message || 'Failed to submit. Please try again.')
+    }
+    successMessage.value = 'Thank you! Your pick is on its way to the big screen.'
+    resetForm()
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'message' in err && typeof (err as { message: unknown }).message === 'string') {
+      errorMessage.value = (err as { message: string }).message
+    } else {
+      errorMessage.value = 'Something went wrong. Please try again.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <main class="min-h-screen bg-off-white text-gray-800">
+    <section class="mx-auto max-w-xl px-4 py-12 sm:py-16">
+      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">Matchmaking Corner</h1>
+      <p class="mt-3 text-gray-600">
+        Know a wonderful single friend? Tell us about them! We'll share the submissions on the big
+        screen at the reception so guests can meet.
+      </p>
+
+      <form class="mt-8 space-y-6" @submit.prevent="submit">
+        <div>
+          <label for="submitterName" class="block text-sm font-medium text-gray-700">Your name</label>
+          <input
+            id="submitterName"
+            v-model="submitterName"
+            required
+            type="text"
+            placeholder="So your friend knows who sent them"
+            class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          />
+        </div>
+
+        <div>
+          <label for="friendName" class="block text-sm font-medium text-gray-700">Your single friend's name</label>
+          <input
+            id="friendName"
+            v-model="friendName"
+            required
+            type="text"
+            placeholder="First name is fine"
+            class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          />
+        </div>
+
+        <div>
+          <label for="contact" class="block text-sm font-medium text-gray-700">Contact</label>
+          <input
+            id="contact"
+            v-model="contact"
+            required
+            type="text"
+            placeholder="IG handle, LINE ID, or phone"
+            class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          />
+        </div>
+
+        <div>
+          <label for="bio" class="block text-sm font-medium text-gray-700">A short intro <span class="text-gray-400">(optional)</span></label>
+          <textarea
+            id="bio"
+            v-model="bio"
+            rows="3"
+            maxlength="500"
+            placeholder="Fun fact, what they're into, why they're a catch…"
+            class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Photo <span class="text-gray-400">(optional)</span></label>
+          <div class="mt-2 flex items-center gap-4">
+            <label class="inline-flex cursor-pointer items-center rounded-full bg-rose-50 px-4 py-2 text-sm text-rose-700 hover:bg-rose-100">
+              <span v-if="!photoPreview">Choose image</span>
+              <span v-else>Replace image</span>
+              <input type="file" accept="image/*" class="hidden" @change="onFileChange" />
+            </label>
+            <button
+              v-if="photoPreview"
+              type="button"
+              class="text-sm text-gray-500 hover:text-gray-700"
+              @click="clearPhoto"
+            >
+              Remove
+            </button>
+          </div>
+          <div v-if="photoPreview" class="mt-4">
+            <img :src="photoPreview" alt="Preview" class="max-h-64 rounded-lg object-cover shadow" />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          :disabled="loading"
+          class="inline-flex items-center rounded-full bg-rose-600 px-6 py-3 text-white shadow hover:bg-rose-700 disabled:opacity-50"
+        >
+          <span v-if="!loading">Send to the big screen</span>
+          <span v-else>Sending…</span>
+        </button>
+
+        <p v-if="successMessage" class="text-green-700">{{ successMessage }}</p>
+        <p v-if="errorMessage" class="text-rose-700">{{ errorMessage }}</p>
+      </form>
+
+      <p class="mt-10 text-sm text-gray-500">
+        By submitting, you confirm your friend is okay with being introduced at the wedding. Entries can
+        be taken down at any time by the moderators.
+      </p>
+    </section>
+  </main>
+</template>


### PR DESCRIPTION
Guests can submit single friends' contact info and optional photos via /matchmaking. Submissions appear on /matchmaking/board, an auto-refreshing grid intended for a projector during the reception. /matchmaking/moderate lets the couple take down entries via a shared token.

Backend adds a matchmaking_submissions table (Drizzle schema + migration 0001), plus POST/GET endpoints and a token-gated PATCH for moderation. Photos are stored as base64 in Postgres; the submit form downscales client-side to keep payloads small, and the backend rejects anything over ~1.5 MB.