### PR TITLE
feat: Thai UI, lottery draw overhaul, matchmaking delete-all, hunt feature

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,8 @@
     "build": "bun build --compile --minify --target bun --outfile dist/server src/index.ts",
     "start": "NODE_ENV=production ./dist/server",
     "db:generate": "drizzle-kit generate --config ./drizzle.config.ts",
-    "db:migrate": "drizzle-kit migrate --config ./drizzle.config.ts"
+    "db:migrate": "drizzle-kit migrate --config ./drizzle.config.ts",
+    "db:seed:hunt": "bun run src/db/seed-hunt.ts"
   },
   "dependencies": {
     "@effect/sql-pg": "^0.47.0",

--- a/apps/backend/src/db/migrations/0003_hunt.sql
+++ b/apps/backend/src/db/migrations/0003_hunt.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "hunt_missions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"position" integer NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"example_thumb_base64" text,
+	"points" integer DEFAULT 10 NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "hunt_photos" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"mission_id" integer NOT NULL,
+	"hunter_token" text NOT NULL,
+	"hunter_name" text NOT NULL,
+	"hunter_table" text,
+	"thumb_base64" text NOT NULL,
+	"full_base64" text NOT NULL,
+	"approved" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+DO $$ BEGIN
+ ALTER TABLE "hunt_photos" ADD CONSTRAINT "hunt_photos_mission_id_hunt_missions_id_fk" FOREIGN KEY ("mission_id") REFERENCES "hunt_missions"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "hunt_photos_mission_id_idx" ON "hunt_photos" ("mission_id");
+CREATE INDEX IF NOT EXISTS "hunt_photos_hunter_token_idx" ON "hunt_photos" ("hunter_token");
+CREATE INDEX IF NOT EXISTS "hunt_photos_created_at_idx" ON "hunt_photos" ("created_at");

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1745452800000,
       "tag": "0002_lottery",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777795200000,
+      "tag": "0003_hunt",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -46,3 +46,34 @@ export const lotteryDraws = pgTable('lottery_draws', {
 
 export type InsertLotteryDraw = typeof lotteryDraws.$inferInsert;
 export type SelectLotteryDraw = typeof lotteryDraws.$inferSelect;
+
+// Mission Hunt — photo scavenger hunt run during the reception. See
+// llm-wiki/requirements/mission-hunt.md for the full spec.
+export const huntMissions = pgTable('hunt_missions', {
+  id: serial('id').primaryKey(),
+  position: integer('position').notNull(),
+  title: text('title').notNull(),
+  description: text('description'),
+  exampleThumbBase64: text('example_thumb_base64'),
+  points: integer('points').notNull().default(10),
+  active: boolean('active').notNull().default(true),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type InsertHuntMission = typeof huntMissions.$inferInsert;
+export type SelectHuntMission = typeof huntMissions.$inferSelect;
+
+export const huntPhotos = pgTable('hunt_photos', {
+  id: serial('id').primaryKey(),
+  missionId: integer('mission_id').notNull().references(() => huntMissions.id, { onDelete: 'cascade' }),
+  hunterToken: text('hunter_token').notNull(),
+  hunterName: text('hunter_name').notNull(),
+  hunterTable: text('hunter_table'),
+  thumbBase64: text('thumb_base64').notNull(),
+  fullBase64: text('full_base64').notNull(),
+  approved: boolean('approved').notNull().default(true),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type InsertHuntPhoto = typeof huntPhotos.$inferInsert;
+export type SelectHuntPhoto = typeof huntPhotos.$inferSelect;

--- a/apps/backend/src/db/seed-hunt.ts
+++ b/apps/backend/src/db/seed-hunt.ts
@@ -1,0 +1,62 @@
+// Idempotent seeder for the Mission Hunt default mission list.
+// Run via: bun run src/db/seed-hunt.ts
+//
+// Inserts the 12 default missions only if the table is empty. Re-running on
+// a non-empty table is a no-op so it's safe to call from CI or post-deploy.
+
+import 'dotenv/config';
+import { Effect } from 'effect';
+import { SqlClient } from '@effect/sql';
+import { LiveDatabase } from './index';
+
+type SeedMission = {
+  position: number;
+  title: string;
+  description: string | null;
+  points: number;
+};
+
+const DEFAULT_MISSIONS: SeedMission[] = [
+  { position: 1, title: 'Selfie with the bride', description: 'A clear shot of your face and Pann\'s', points: 10 },
+  { position: 2, title: 'Selfie with the groom', description: 'A clear shot of your face and Som\'s', points: 10 },
+  { position: 3, title: 'The wedding cake', description: 'Capture the cake before it gets cut', points: 10 },
+  { position: 4, title: 'Your dinner plate', description: 'Show us what you\'re eating tonight', points: 10 },
+  { position: 5, title: 'Your table number / centerpiece', description: 'Whatever\'s in front of you on the table', points: 10 },
+  { position: 6, title: 'Group photo with at least 5 people', description: 'The more, the merrier', points: 15 },
+  { position: 7, title: 'The most stylish auntie', description: 'You know the one', points: 15 },
+  { position: 8, title: 'Two strangers who just met', description: 'Bonus if they\'re laughing', points: 20 },
+  { position: 9, title: 'A kid on the dance floor', description: 'Free-form movement strongly encouraged', points: 20 },
+  { position: 10, title: 'Someone crying happy tears', description: 'Be tasteful — happy tears only', points: 20 },
+  { position: 11, title: 'Recreate one of Som & Pann\'s pre-wedding photos', description: 'Use the gallery for reference', points: 25 },
+  { position: 12, title: 'Best dance move (action shot)', description: 'Catch them mid-air if you can', points: 25 },
+];
+
+async function main() {
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const existing = yield* sql<{ count: string }>`select count(*) as count from hunt_missions`;
+      const count = Number(existing[0]?.count ?? 0);
+      if (count > 0) {
+        return { skipped: true, count };
+      }
+      for (const m of DEFAULT_MISSIONS) {
+        yield* sql`
+          insert into hunt_missions (position, title, description, points, active)
+          values (${m.position}, ${m.title}, ${m.description}, ${m.points}, true)
+        `;
+      }
+      return { skipped: false, count: DEFAULT_MISSIONS.length };
+    }).pipe(Effect.provide(LiveDatabase)),
+  );
+  if (result.skipped) {
+    console.log(`✋ hunt_missions already has ${result.count} rows — seed skipped.`);
+  } else {
+    console.log(`✅ Seeded ${result.count} default missions into hunt_missions.`);
+  }
+}
+
+main().catch((err) => {
+  console.error('Failed to seed hunt missions:', err);
+  process.exit(1);
+});

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -7,6 +7,7 @@ import { LiveDatabase } from './db';
 import { rsvpRoutes } from './routes/rsvp';
 import { matchmakingRoutes } from './routes/matchmaking';
 import { lotteryRoutes } from './routes/lottery';
+import { huntRoutes } from './routes/hunt';
 
 const dbHealthCheck = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -34,6 +35,7 @@ const app = new Elysia()
   .use(rsvpRoutes)
   .use(matchmakingRoutes)
   .use(lotteryRoutes)
+  .use(huntRoutes)
   .listen(3000);
 
 Effect.runPromise(dbHealthCheck)

--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -5,7 +5,7 @@ export function requireServiceKey(
   const key = process.env.SECRET_SERVICE_KEY;
   if (key && headers['x-service-key'] !== key) {
     set.status = 401;
-    return { success: false, message: 'Unauthorized' };
+    return { success: false, message: 'ไม่ได้รับอนุญาต' };
   }
   return null;
 }
@@ -17,7 +17,7 @@ export function requireModToken(
   const token = process.env.MODERATE_KEY;
   if (!token || headers['x-mod-token'] !== token) {
     set.status = 401;
-    return { success: false, message: 'Unauthorized' };
+    return { success: false, message: 'ไม่ได้รับอนุญาต' };
   }
   return null;
 }

--- a/apps/backend/src/routes/hunt.ts
+++ b/apps/backend/src/routes/hunt.ts
@@ -1,0 +1,649 @@
+import { Elysia, t } from 'elysia';
+import { Effect } from 'effect';
+import { SqlClient } from '@effect/sql';
+import { LiveDatabase } from '../db';
+import { requireServiceKey, requireModToken } from '../lib/auth';
+
+// Mission Hunt routes — see llm-wiki/requirements/mission-hunt.md.
+// Photos default approved=true (opt-out moderation, mirrors matchmaking).
+// Mod endpoints gated by x-mod-token; guest endpoints by x-service-key (when configured).
+
+// 30-second display delay between photo insert and mosaic visibility.
+const FEED_DELAY_MS = 30_000;
+const PHOTO_FULL_MAX_BYTES = 2_200_000;
+const PHOTO_THUMB_MAX_BYTES = 200_000;
+
+type MissionRow = {
+  id: number;
+  position: number;
+  title: string;
+  description: string | null;
+  example_thumb_base64: string | null;
+  points: number;
+  active: boolean;
+  created_at: string;
+};
+
+type PhotoRow = {
+  id: number;
+  mission_id: number;
+  hunter_token: string;
+  hunter_name: string;
+  hunter_table: string | null;
+  thumb_base64: string;
+  full_base64: string;
+  approved: boolean;
+  created_at: string;
+};
+
+export const huntRoutes = new Elysia()
+  // ────────────────────────────────────────────────────────────────────
+  // Guest endpoints
+  // ────────────────────────────────────────────────────────────────────
+  .get('/api/hunt/missions', async ({ headers, set }) => {
+    const authErr = requireServiceKey(headers, set);
+    if (authErr) return authErr;
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<Omit<MissionRow, 'description'> & { description: string | null }>`
+            select id, position, title, description, example_thumb_base64, points, active, created_at
+            from hunt_missions
+            where active = true
+            order by position asc, id asc
+          `;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return { success: true, missions: rows };
+    } catch (error) {
+      console.error('Failed to fetch hunt missions', error);
+      return { success: false, message: 'Failed to fetch missions.' };
+    }
+  })
+  .post('/api/hunt/photo', async ({ body, headers, set }) => {
+    const authErr = requireServiceKey(headers, set);
+    if (authErr) return authErr;
+
+    if (body.fullBase64.length > PHOTO_FULL_MAX_BYTES) {
+      set.status = 413;
+      return { success: false, message: 'Photo too large. Please pick a smaller image.' };
+    }
+    if (body.thumbBase64.length > PHOTO_THUMB_MAX_BYTES) {
+      set.status = 413;
+      return { success: false, message: 'Thumbnail too large.' };
+    }
+    if (!body.fullBase64.startsWith('data:image/jpeg;base64,') ||
+        !body.thumbBase64.startsWith('data:image/jpeg;base64,')) {
+      set.status = 400;
+      return { success: false, message: 'Photo must be a JPEG data URL.' };
+    }
+
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+
+          // Verify the mission exists and is active.
+          const missions = yield* sql<{ id: number; points: number }>`
+            select id, points from hunt_missions where id = ${body.missionId} and active = true
+          `;
+          if (missions.length === 0) {
+            return { kind: 'mission_missing' as const };
+          }
+          const missionPoints = missions[0]!.points;
+
+          // Did this hunter already have an approved photo for this mission?
+          const prior = yield* sql<{ count: string }>`
+            select count(*) as count
+            from hunt_photos
+            where mission_id = ${body.missionId}
+              and hunter_token = ${body.hunterToken}
+              and approved = true
+          `;
+          const alreadyEarned = Number(prior[0]?.count ?? 0) > 0;
+
+          const inserted = yield* sql<{ id: number; created_at: string }>`
+            insert into hunt_photos
+              (mission_id, hunter_token, hunter_name, hunter_table, thumb_base64, full_base64)
+            values
+              (${body.missionId}, ${body.hunterToken}, ${body.hunterName.trim()},
+               ${body.hunterTable?.trim() || null}, ${body.thumbBase64}, ${body.fullBase64})
+            returning id, created_at
+          `;
+
+          return {
+            kind: 'ok' as const,
+            id: inserted[0]!.id,
+            createdAt: inserted[0]!.created_at,
+            pointsAwarded: alreadyEarned ? 0 : missionPoints,
+          };
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+
+      if (result.kind === 'mission_missing') {
+        set.status = 404;
+        return { success: false, message: 'Mission not found or inactive.' };
+      }
+      return {
+        success: true,
+        photo: { id: result.id, createdAt: result.createdAt },
+        pointsAwarded: result.pointsAwarded,
+      };
+    } catch (error) {
+      console.error('Failed to save hunt photo', error);
+      return { success: false, message: 'Failed to save photo.' };
+    }
+  }, {
+    body: t.Object({
+      missionId: t.Number(),
+      hunterToken: t.String({ minLength: 8, maxLength: 64 }),
+      hunterName: t.String({ minLength: 1, maxLength: 80 }),
+      hunterTable: t.Optional(t.String({ maxLength: 20 })),
+      thumbBase64: t.String(),
+      fullBase64: t.String(),
+    }),
+  })
+  .get('/api/hunt/feed', async ({ query, headers, set }) => {
+    const authErr = requireServiceKey(headers, set);
+    if (authErr) return authErr;
+    const limit = Math.min(Math.max(Number(query.limit ?? 60) || 60, 1), 200);
+    const since = typeof query.since === 'string' ? new Date(query.since) : null;
+    const sinceValid = since && !Number.isNaN(since.getTime());
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          // Photos are visible to the mosaic only after FEED_DELAY_MS elapsed,
+          // giving moderators a window to flag.
+          const cutoff = new Date(Date.now() - FEED_DELAY_MS);
+          if (sinceValid) {
+            return yield* sql<Omit<PhotoRow, 'full_base64'>>`
+              select id, mission_id, hunter_token, hunter_name, hunter_table,
+                     thumb_base64, '' as full_base64, approved, created_at
+              from hunt_photos
+              where approved = true
+                and created_at <= ${cutoff}
+                and created_at > ${since!}
+              order by created_at desc
+              limit ${limit}
+            `;
+          }
+          return yield* sql<Omit<PhotoRow, 'full_base64'>>`
+            select id, mission_id, hunter_token, hunter_name, hunter_table,
+                   thumb_base64, '' as full_base64, approved, created_at
+            from hunt_photos
+            where approved = true
+              and created_at <= ${cutoff}
+            order by created_at desc
+            limit ${limit}
+          `;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return {
+        success: true,
+        photos: rows.map((r) => ({
+          id: r.id,
+          missionId: r.mission_id,
+          hunterName: r.hunter_name,
+          hunterTable: r.hunter_table,
+          thumbBase64: r.thumb_base64,
+          createdAt: r.created_at,
+        })),
+      };
+    } catch (error) {
+      console.error('Failed to fetch hunt feed', error);
+      return { success: false, message: 'Failed to fetch feed.' };
+    }
+  })
+  .get('/api/hunt/photo/:id', async ({ params, headers, set }) => {
+    const authErr = requireServiceKey(headers, set);
+    if (authErr) return authErr;
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      set.status = 400;
+      return { success: false, message: 'Invalid id' };
+    }
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<{ id: number; mission_id: number; hunter_name: string; full_base64: string; approved: boolean; created_at: string }>`
+            select id, mission_id, hunter_name, full_base64, approved, created_at
+            from hunt_photos
+            where id = ${id} and approved = true
+          `;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      const row = rows[0];
+      if (!row) {
+        set.status = 404;
+        return { success: false, message: 'Photo not found.' };
+      }
+      return {
+        success: true,
+        photo: {
+          id: row.id,
+          missionId: row.mission_id,
+          hunterName: row.hunter_name,
+          fullBase64: row.full_base64,
+          createdAt: row.created_at,
+        },
+      };
+    } catch (error) {
+      console.error('Failed to fetch hunt photo', error);
+      return { success: false, message: 'Failed to fetch photo.' };
+    }
+  })
+  .get('/api/hunt/leaderboard', async ({ query, headers, set }) => {
+    const authErr = requireServiceKey(headers, set);
+    if (authErr) return authErr;
+    const limit = Math.min(Math.max(Number(query.limit ?? 20) || 20, 1), 100);
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          // Score = sum of points across distinct missions the hunter completed
+          // (multiple photos for the same mission count once).
+          return yield* sql<{
+            hunter_token: string;
+            hunter_name: string;
+            hunter_table: string | null;
+            missions_completed: string;
+            total_points: string;
+          }>`
+            with hunter_missions as (
+              select distinct p.hunter_token, p.mission_id
+              from hunt_photos p
+              where p.approved = true
+            ),
+            hunter_latest_name as (
+              select distinct on (hunter_token)
+                hunter_token, hunter_name, hunter_table
+              from hunt_photos
+              where approved = true
+              order by hunter_token, created_at desc
+            )
+            select
+              hm.hunter_token,
+              hln.hunter_name,
+              hln.hunter_table,
+              count(*)::text as missions_completed,
+              sum(m.points)::text as total_points
+            from hunter_missions hm
+            join hunt_missions m on m.id = hm.mission_id
+            join hunter_latest_name hln on hln.hunter_token = hm.hunter_token
+            group by hm.hunter_token, hln.hunter_name, hln.hunter_table
+            order by sum(m.points) desc, count(*) desc, hln.hunter_name asc
+            limit ${limit}
+          `;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return {
+        success: true,
+        hunters: rows.map((r, i) => ({
+          rank: i + 1,
+          hunterName: r.hunter_name,
+          hunterTable: r.hunter_table,
+          missionsCompleted: Number(r.missions_completed),
+          totalPoints: Number(r.total_points),
+        })),
+      };
+    } catch (error) {
+      console.error('Failed to fetch hunt leaderboard', error);
+      return { success: false, message: 'Failed to fetch leaderboard.' };
+    }
+  })
+  .get('/api/hunt/me', async ({ query, headers, set }) => {
+    const authErr = requireServiceKey(headers, set);
+    if (authErr) return authErr;
+    const token = typeof query.token === 'string' ? query.token : '';
+    if (!token) {
+      set.status = 400;
+      return { success: false, message: 'token query param required.' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const completed = yield* sql<{ mission_id: number; points: number }>`
+            select distinct p.mission_id, m.points
+            from hunt_photos p
+            join hunt_missions m on m.id = p.mission_id
+            where p.hunter_token = ${token} and p.approved = true
+          `;
+          return completed;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      const completedMissionIds = result.map((r) => r.mission_id);
+      const totalPoints = result.reduce((sum, r) => sum + Number(r.points), 0);
+      return { success: true, completedMissionIds, totalPoints };
+    } catch (error) {
+      console.error('Failed to fetch hunt me', error);
+      return { success: false, message: 'Failed to fetch hunter state.' };
+    }
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  // Moderator endpoints — photos
+  // ────────────────────────────────────────────────────────────────────
+  .get('/api/hunt/photos/all', async ({ headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<Omit<PhotoRow, 'full_base64'>>`
+            select id, mission_id, hunter_token, hunter_name, hunter_table,
+                   thumb_base64, '' as full_base64, approved, created_at
+            from hunt_photos
+            order by created_at desc
+            limit 500
+          `;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return {
+        success: true,
+        photos: rows.map((r) => ({
+          id: r.id,
+          missionId: r.mission_id,
+          hunterToken: r.hunter_token,
+          hunterName: r.hunter_name,
+          hunterTable: r.hunter_table,
+          thumbBase64: r.thumb_base64,
+          approved: r.approved,
+          createdAt: r.created_at,
+        })),
+      };
+    } catch (error) {
+      console.error('Failed to fetch all hunt photos', error);
+      return { success: false, message: 'Failed to fetch photos.' };
+    }
+  })
+  .patch('/api/hunt/photo/:id', async ({ params, body, headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      set.status = 400;
+      return { success: false, message: 'Invalid id' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const rows = yield* sql<{ id: number; approved: boolean }>`
+            update hunt_photos set approved = ${body.approved} where id = ${id}
+            returning id, approved
+          `;
+          return rows[0];
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      if (!result) {
+        set.status = 404;
+        return { success: false, message: 'Not found' };
+      }
+      return { success: true, photo: result };
+    } catch (error) {
+      console.error('Failed to update hunt photo', error);
+      return { success: false, message: 'Failed to update photo.' };
+    }
+  }, {
+    body: t.Object({ approved: t.Boolean() }),
+  })
+  .delete('/api/hunt/photo/:id', async ({ params, headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      set.status = 400;
+      return { success: false, message: 'Invalid id' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const rows = yield* sql<{ id: number }>`delete from hunt_photos where id = ${id} returning id`;
+          return rows[0];
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      if (!result) {
+        set.status = 404;
+        return { success: false, message: 'Not found' };
+      }
+      return { success: true, deletedPhotoId: result.id };
+    } catch (error) {
+      console.error('Failed to delete hunt photo', error);
+      return { success: false, message: 'Failed to delete photo.' };
+    }
+  })
+  .delete('/api/hunt/photos', async ({ headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    try {
+      const deleted = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const rows = yield* sql<{ count: string }>`
+            with d as (delete from hunt_photos returning 1)
+            select count(*)::text as count from d
+          `;
+          return Number(rows[0]?.count ?? 0);
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return { success: true, deletedPhotoCount: deleted };
+    } catch (error) {
+      console.error('Failed to wipe hunt photos', error);
+      return { success: false, message: 'Failed to wipe photos.' };
+    }
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  // Moderator endpoints — missions
+  // ────────────────────────────────────────────────────────────────────
+  .get('/api/hunt/missions/all', async ({ headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<MissionRow>`
+            select id, position, title, description, example_thumb_base64, points, active, created_at
+            from hunt_missions
+            order by position asc, id asc
+          `;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return { success: true, missions: rows };
+    } catch (error) {
+      console.error('Failed to fetch all hunt missions', error);
+      return { success: false, message: 'Failed to fetch missions.' };
+    }
+  })
+  .post('/api/hunt/missions', async ({ body, headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    if (body.exampleThumbBase64 && body.exampleThumbBase64.length > PHOTO_THUMB_MAX_BYTES) {
+      set.status = 413;
+      return { success: false, message: 'Example thumbnail too large.' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          // If position is omitted, append at the end.
+          let position = body.position;
+          if (position === undefined) {
+            const max = yield* sql<{ max: number | null }>`select coalesce(max(position), 0) as max from hunt_missions`;
+            position = (max[0]?.max ?? 0) + 1;
+          }
+          const rows = yield* sql<MissionRow>`
+            insert into hunt_missions
+              (position, title, description, example_thumb_base64, points, active)
+            values
+              (${position}, ${body.title.trim()}, ${body.description?.trim() || null},
+               ${body.exampleThumbBase64 ?? null}, ${body.points}, ${body.active ?? true})
+            returning id, position, title, description, example_thumb_base64, points, active, created_at
+          `;
+          return rows[0]!;
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return { success: true, mission: result };
+    } catch (error) {
+      console.error('Failed to create hunt mission', error);
+      return { success: false, message: 'Failed to create mission.' };
+    }
+  }, {
+    body: t.Object({
+      title: t.String({ minLength: 1, maxLength: 120 }),
+      description: t.Optional(t.String({ maxLength: 300 })),
+      points: t.Number({ minimum: 1, maximum: 999 }),
+      position: t.Optional(t.Number()),
+      active: t.Optional(t.Boolean()),
+      exampleThumbBase64: t.Optional(t.String()),
+    }),
+  })
+  .patch('/api/hunt/missions/:id', async ({ params, body, headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      set.status = 400;
+      return { success: false, message: 'Invalid id' };
+    }
+    if (body.exampleThumbBase64 && body.exampleThumbBase64.length > PHOTO_THUMB_MAX_BYTES) {
+      set.status = 413;
+      return { success: false, message: 'Example thumbnail too large.' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const rows = yield* sql<MissionRow>`
+            update hunt_missions set
+              title = coalesce(${body.title?.trim() ?? null}, title),
+              description = case when ${body.description !== undefined}::boolean then ${body.description?.trim() || null} else description end,
+              points = coalesce(${body.points ?? null}, points),
+              position = coalesce(${body.position ?? null}, position),
+              active = coalesce(${body.active ?? null}, active),
+              example_thumb_base64 = case when ${body.exampleThumbBase64 !== undefined}::boolean then ${body.exampleThumbBase64 ?? null} else example_thumb_base64 end
+            where id = ${id}
+            returning id, position, title, description, example_thumb_base64, points, active, created_at
+          `;
+          return rows[0];
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      if (!result) {
+        set.status = 404;
+        return { success: false, message: 'Mission not found.' };
+      }
+      return { success: true, mission: result };
+    } catch (error) {
+      console.error('Failed to update hunt mission', error);
+      return { success: false, message: 'Failed to update mission.' };
+    }
+  }, {
+    body: t.Object({
+      title: t.Optional(t.String({ minLength: 1, maxLength: 120 })),
+      description: t.Optional(t.String({ maxLength: 300 })),
+      points: t.Optional(t.Number({ minimum: 1, maximum: 999 })),
+      position: t.Optional(t.Number()),
+      active: t.Optional(t.Boolean()),
+      exampleThumbBase64: t.Optional(t.String()),
+    }),
+  })
+  .delete('/api/hunt/missions/:id', async ({ params, headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      set.status = 400;
+      return { success: false, message: 'Invalid id' };
+    }
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const photoCount = yield* sql<{ count: string }>`
+            select count(*) as count from hunt_photos where mission_id = ${id}
+          `;
+          const rows = yield* sql<{ id: number }>`delete from hunt_missions where id = ${id} returning id`;
+          return { row: rows[0], deletedPhotoCount: Number(photoCount[0]?.count ?? 0) };
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      if (!result.row) {
+        set.status = 404;
+        return { success: false, message: 'Mission not found.' };
+      }
+      return {
+        success: true,
+        deletedMissionId: result.row.id,
+        deletedPhotoCount: result.deletedPhotoCount,
+      };
+    } catch (error) {
+      console.error('Failed to delete hunt mission', error);
+      return { success: false, message: 'Failed to delete mission.' };
+    }
+  })
+  .post('/api/hunt/missions/reorder', async ({ body, headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    if (!Array.isArray(body.orderedIds) || body.orderedIds.length === 0) {
+      set.status = 400;
+      return { success: false, message: 'orderedIds must be a non-empty array.' };
+    }
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          // Two-step rewrite to avoid hypothetical unique-constraint conflicts:
+          // bump everything to a non-overlapping range, then assign final positions.
+          yield* sql`update hunt_missions set position = position + 100000`;
+          for (let i = 0; i < body.orderedIds.length; i++) {
+            const id = body.orderedIds[i]!;
+            const newPos = i + 1;
+            yield* sql`update hunt_missions set position = ${newPos} where id = ${id}`;
+          }
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return { success: true, count: body.orderedIds.length };
+    } catch (error) {
+      console.error('Failed to reorder hunt missions', error);
+      return { success: false, message: 'Failed to reorder missions.' };
+    }
+  }, {
+    body: t.Object({ orderedIds: t.Array(t.Number()) }),
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  // Moderator endpoint — full reset (photos AND missions)
+  // ────────────────────────────────────────────────────────────────────
+  .delete('/api/hunt/all', async ({ headers, set }) => {
+    const authErr = requireModToken(headers, set);
+    if (authErr) return authErr;
+    try {
+      const counts = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const photos = yield* sql<{ count: string }>`
+            with d as (delete from hunt_photos returning 1)
+            select count(*)::text as count from d
+          `;
+          const missions = yield* sql<{ count: string }>`
+            with d as (delete from hunt_missions returning 1)
+            select count(*)::text as count from d
+          `;
+          return {
+            deletedPhotoCount: Number(photos[0]?.count ?? 0),
+            deletedMissionCount: Number(missions[0]?.count ?? 0),
+          };
+        }).pipe(Effect.provide(LiveDatabase)),
+      );
+      return { success: true, ...counts };
+    } catch (error) {
+      console.error('Failed to full-reset hunt', error);
+      return { success: false, message: 'Failed to reset hunt data.' };
+    }
+  });

--- a/apps/backend/src/routes/lottery.ts
+++ b/apps/backend/src/routes/lottery.ts
@@ -17,7 +17,7 @@ export const lotteryRoutes = new Elysia()
     const num = body.number.trim();
     if (!/^\d{6}$/.test(num)) {
       set.status = 400;
-      return { success: false, message: 'Number must be exactly 6 digits.' };
+      return { success: false, message: 'หมายเลขต้องมี 6 หลักเท่านั้น' };
     }
     try {
       const result = await Effect.runPromise(
@@ -35,10 +35,10 @@ export const lotteryRoutes = new Elysia()
     } catch (error: unknown) {
       if (isUniqueViolation(error)) {
         set.status = 409;
-        return { success: false, message: 'That number is already taken. Try a different one.' };
+        return { success: false, message: 'หมายเลขนี้ถูกใช้ไปแล้ว กรุณาเลือกหมายเลขอื่น' };
       }
       console.error('Failed to save lottery entry', error);
-      return { success: false, message: 'Failed to save entry.' };
+      return { success: false, message: 'ไม่สามารถบันทึกข้อมูลได้' };
     }
   }, {
     body: t.Object({
@@ -59,7 +59,7 @@ export const lotteryRoutes = new Elysia()
       return { success: true, numbers: rows.map(r => r.number) };
     } catch (error) {
       console.error('Failed to fetch lottery numbers', error);
-      return { success: false, message: 'Failed to fetch numbers.' };
+      return { success: false, message: 'ไม่สามารถดึงข้อมูลหมายเลขได้' };
     }
   })
   .get('/api/lottery/entries', async ({ headers, set }) => {
@@ -77,7 +77,7 @@ export const lotteryRoutes = new Elysia()
       return { success: true, entries: rows };
     } catch (error) {
       console.error('Failed to fetch lottery entries', error);
-      return { success: false, message: 'Failed to fetch entries.' };
+      return { success: false, message: 'ไม่สามารถดึงข้อมูลได้' };
     }
   })
   .post('/api/lottery/draw', async ({ body, headers, set }) => {
@@ -86,7 +86,7 @@ export const lotteryRoutes = new Elysia()
     const digitCount = PRIZE_DIGITS[body.prizeRank];
     if (!digitCount) {
       set.status = 400;
-      return { success: false, message: 'prizeRank must be 1, 2, or 3.' };
+      return { success: false, message: 'ลำดับรางวัลต้องเป็น 1, 2 หรือ 3 เท่านั้น' };
     }
     try {
       // Build the pool from actual submitted entries
@@ -98,7 +98,7 @@ export const lotteryRoutes = new Elysia()
       );
       if (entries.length === 0) {
         set.status = 400;
-        return { success: false, message: 'No entries to draw from.' };
+        return { success: false, message: 'ยังไม่มีผู้เข้าร่วมในการจับรางวัล' };
       }
 
       // For 2nd/3rd prize use distinct suffix pool so the draw is over unique
@@ -119,10 +119,10 @@ export const lotteryRoutes = new Elysia()
     } catch (error: unknown) {
       if (isUniqueViolation(error)) {
         set.status = 409;
-        return { success: false, message: `Prize ${body.prizeRank} has already been drawn.` };
+        return { success: false, message: `รางวัลที่ ${body.prizeRank} ถูกจับไปแล้ว` };
       }
       console.error('Failed to draw lottery prize', error);
-      return { success: false, message: 'Failed to draw prize.' };
+      return { success: false, message: 'ไม่สามารถจับรางวัลได้' };
     }
   }, {
     body: t.Object({ prizeRank: t.Number() }),
@@ -152,7 +152,7 @@ export const lotteryRoutes = new Elysia()
       return { success: true, results };
     } catch (error) {
       console.error('Failed to fetch lottery results', error);
-      return { success: false, message: 'Failed to fetch results.' };
+      return { success: false, message: 'ไม่สามารถดึงผลการจับรางวัลได้' };
     }
   })
   .delete('/api/lottery/draws', async ({ headers, set }) => {
@@ -168,7 +168,7 @@ export const lotteryRoutes = new Elysia()
       return { success: true };
     } catch (error) {
       console.error('Failed to reset lottery draws', error);
-      return { success: false, message: 'Failed to reset.' };
+      return { success: false, message: 'ไม่สามารถรีเซ็ตข้อมูลได้' };
     }
   })
   .delete('/api/lottery', async ({ headers, set }) => {
@@ -185,6 +185,6 @@ export const lotteryRoutes = new Elysia()
       return { success: true };
     } catch (error) {
       console.error('Failed to full reset lottery', error);
-      return { success: false, message: 'Failed to reset.' };
+      return { success: false, message: 'ไม่สามารถรีเซ็ตข้อมูลได้' };
     }
   });

--- a/apps/backend/src/routes/matchmaking.ts
+++ b/apps/backend/src/routes/matchmaking.ts
@@ -10,7 +10,7 @@ export const matchmakingRoutes = new Elysia()
     if (authErr) return authErr;
     if (body.photoBase64 && body.photoBase64.length > 2_200_000) {
       set.status = 413;
-      return { success: false, message: 'Photo too large. Please pick a smaller image.' };
+      return { success: false, message: 'รูปภาพมีขนาดใหญ่เกินไป กรุณาเลือกรูปที่เล็กกว่า' };
     }
     try {
       const result = await Effect.runPromise(
@@ -30,7 +30,7 @@ export const matchmakingRoutes = new Elysia()
       return { success: true, submission: result };
     } catch (error) {
       console.error('Failed to save matchmaking submission', error);
-      return { success: false, message: 'Failed to save submission' };
+      return { success: false, message: 'ไม่สามารถบันทึกข้อมูลได้' };
     }
   }, {
     body: t.Object({
@@ -62,7 +62,7 @@ export const matchmakingRoutes = new Elysia()
       return { success: true, submissions: rows };
     } catch (error) {
       console.error('Failed to fetch matchmaking submissions', error);
-      return { success: false, message: 'Failed to fetch submissions' };
+      return { success: false, message: 'ไม่สามารถดึงข้อมูลได้' };
     }
   })
   .get('/api/matchmaking/all', async ({ headers, set }) => {
@@ -85,7 +85,7 @@ export const matchmakingRoutes = new Elysia()
       return { success: true, submissions: rows };
     } catch (error) {
       console.error('Failed to fetch all matchmaking submissions', error);
-      return { success: false, message: 'Failed to fetch submissions' };
+      return { success: false, message: 'ไม่สามารถดึงข้อมูลได้' };
     }
   })
   .patch('/api/matchmaking/:id', async ({ params, body, headers, set }) => {
@@ -94,7 +94,7 @@ export const matchmakingRoutes = new Elysia()
     const id = Number(params.id);
     if (!Number.isInteger(id) || id <= 0) {
       set.status = 400;
-      return { success: false, message: 'Invalid id' };
+      return { success: false, message: 'ID ไม่ถูกต้อง' };
     }
     try {
       const result = await Effect.runPromise(
@@ -111,12 +111,12 @@ export const matchmakingRoutes = new Elysia()
       );
       if (!result) {
         set.status = 404;
-        return { success: false, message: 'Not found' };
+        return { success: false, message: 'ไม่พบข้อมูล' };
       }
       return { success: true, submission: result };
     } catch (error) {
       console.error('Failed to update matchmaking submission', error);
-      return { success: false, message: 'Failed to update submission' };
+      return { success: false, message: 'ไม่สามารถอัปเดตข้อมูลได้' };
     }
   }, {
     body: t.Object({ approved: t.Boolean() }),
@@ -134,6 +134,6 @@ export const matchmakingRoutes = new Elysia()
       return { success: true };
     } catch (error) {
       console.error('Failed to delete all matchmaking submissions', error);
-      return { success: false, message: 'Failed to delete submissions.' };
+      return { success: false, message: 'ไม่สามารถลบข้อมูลได้' };
     }
   });

--- a/apps/frontend/src/router/index.ts
+++ b/apps/frontend/src/router/index.ts
@@ -67,6 +67,21 @@ const router = createRouter({
       name: 'lottery-moderate',
       component: () => import('../views/LotteryModerateView.vue'),
     },
+    {
+      path: '/hunt',
+      name: 'hunt',
+      component: () => import('../views/HuntView.vue'),
+    },
+    {
+      path: '/hunt/board',
+      name: 'hunt-board',
+      component: () => import('../views/HuntBoardView.vue'),
+    },
+    {
+      path: '/hunt/moderate',
+      name: 'hunt-moderate',
+      component: () => import('../views/HuntModerateView.vue'),
+    },
     // todo add video presentation
     // todo pre wedding photo
     // todo seat plan

--- a/apps/frontend/src/views/HuntBoardView.vue
+++ b/apps/frontend/src/views/HuntBoardView.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { apiFetch } from '@/lib/api'
+
+type FeedPhoto = {
+  id: number
+  missionId: number
+  hunterName: string
+  hunterTable: string | null
+  thumbBase64: string
+  createdAt: string
+}
+
+type Hunter = {
+  rank: number
+  hunterName: string
+  hunterTable: string | null
+  missionsCompleted: number
+  totalPoints: number
+}
+
+type Mission = { id: number; title: string }
+
+const photos = ref<FeedPhoto[]>([])
+const leaders = ref<Hunter[]>([])
+const missionMap = ref<Map<number, string>>(new Map())
+const error = ref<string | null>(null)
+const lastSeen = ref<string | null>(null)
+const shuffleSeed = ref(0)
+
+const POLL_FEED_MS = 8_000
+const POLL_LEADERBOARD_MS = 12_000
+const SHUFFLE_MS = 30_000
+const MAX_TILES = 80
+
+let feedTimer: ReturnType<typeof setInterval> | null = null
+let leaderTimer: ReturnType<typeof setInterval> | null = null
+let shuffleTimer: ReturnType<typeof setInterval> | null = null
+
+async function loadMissions() {
+  try {
+    const res = await apiFetch('/api/hunt/missions')
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) return
+    const list = (data.missions ?? []) as Mission[]
+    missionMap.value = new Map(list.map((m) => [m.id, m.title]))
+  } catch { /* silent — projector should never crash */ }
+}
+
+async function pollFeed() {
+  try {
+    const url = lastSeen.value
+      ? `/api/hunt/feed?since=${encodeURIComponent(lastSeen.value)}&limit=60`
+      : '/api/hunt/feed?limit=60'
+    const res = await apiFetch(url)
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) return
+    const incoming = (data.photos ?? []) as FeedPhoto[]
+    if (incoming.length > 0) {
+      // Newest first; merge while keeping uniqueness by id.
+      const merged = [...incoming, ...photos.value].slice(0, MAX_TILES)
+      const seen = new Set<number>()
+      photos.value = merged.filter((p) => (seen.has(p.id) ? false : (seen.add(p.id), true)))
+      // Track newest createdAt for delta polls.
+      const newest = incoming.reduce((acc, p) => (p.createdAt > acc ? p.createdAt : acc), lastSeen.value ?? '')
+      lastSeen.value = newest || lastSeen.value
+    }
+    error.value = null
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Lost connection'
+  }
+}
+
+async function pollLeaderboard() {
+  try {
+    const res = await apiFetch('/api/hunt/leaderboard?limit=5')
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) return
+    leaders.value = (data.hunters ?? []) as Hunter[]
+  } catch { /* silent */ }
+}
+
+const arrangedPhotos = computed(() => {
+  // Tie shuffle to shuffleSeed so the layout re-orders every SHUFFLE_MS.
+  const seed = shuffleSeed.value
+  const arr = [...photos.value]
+  // Fisher-Yates with seeded RNG (mulberry32).
+  let s = seed >>> 0
+  function rand() { s = (s + 0x6D2B79F5) >>> 0; let t = s; t = Math.imul(t ^ (t >>> 15), t | 1); t ^= t + Math.imul(t ^ (t >>> 7), t | 61); return ((t ^ (t >>> 14)) >>> 0) / 4294967296 }
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1))
+    ;[arr[i], arr[j]] = [arr[j]!, arr[i]!]
+  }
+  return arr
+})
+
+onMounted(async () => {
+  await loadMissions()
+  await pollFeed()
+  await pollLeaderboard()
+  feedTimer = setInterval(pollFeed, POLL_FEED_MS)
+  leaderTimer = setInterval(pollLeaderboard, POLL_LEADERBOARD_MS)
+  shuffleTimer = setInterval(() => {
+    shuffleSeed.value = (shuffleSeed.value + 1) % 100000
+  }, SHUFFLE_MS)
+})
+
+onUnmounted(() => {
+  if (feedTimer) clearInterval(feedTimer)
+  if (leaderTimer) clearInterval(leaderTimer)
+  if (shuffleTimer) clearInterval(shuffleTimer)
+})
+</script>
+
+<template>
+  <main class="min-h-screen bg-[#0b0c1a] text-white px-6 py-6 flex flex-col">
+    <header class="mb-5 flex items-baseline justify-between gap-4">
+      <div>
+        <p class="text-xs uppercase tracking-[0.3em] text-rose-400">Som &amp; Pann · Mission Hunt</p>
+        <h1 class="font-cookie mt-1 text-5xl text-rose-300">The Wall</h1>
+      </div>
+      <p class="text-sm text-gray-500">Scan to play · {{ photos.length }} memories</p>
+    </header>
+
+    <p v-if="error" class="mb-3 text-center text-rose-400 text-xs">{{ error }}</p>
+
+    <!-- Mosaic -->
+    <section
+      v-if="arrangedPhotos.length > 0"
+      class="flex-1 grid gap-2 sm:gap-3"
+      style="grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); grid-auto-rows: 140px"
+    >
+      <article
+        v-for="photo in arrangedPhotos"
+        :key="photo.id"
+        class="group relative overflow-hidden rounded-xl border border-white/5 bg-white/5 shadow-lg transition-opacity duration-700"
+      >
+        <img
+          :src="photo.thumbBase64"
+          :alt="photo.hunterName"
+          class="h-full w-full object-cover"
+          loading="lazy"
+        />
+        <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-2">
+          <p class="text-[11px] font-medium text-white/90 truncate">{{ photo.hunterName }}</p>
+          <p class="text-[10px] uppercase tracking-wide text-rose-300/80 truncate">{{ missionMap.get(photo.missionId) ?? 'Mission' }}</p>
+        </div>
+      </article>
+    </section>
+
+    <section
+      v-else
+      class="flex flex-1 items-center justify-center text-center"
+    >
+      <div>
+        <p class="font-cookie text-5xl text-rose-300">Waiting for the first shot…</p>
+        <p class="mt-3 text-gray-500">Photos appear here ~30 seconds after submission.</p>
+      </div>
+    </section>
+
+    <!-- Leaderboard strip -->
+    <footer
+      v-if="leaders.length > 0"
+      class="mt-4 rounded-2xl border border-white/10 bg-white/5 px-5 py-3 backdrop-blur"
+    >
+      <div class="flex items-center justify-between gap-4 text-sm">
+        <p class="text-xs uppercase tracking-[0.25em] text-rose-300/80">Top Hunters</p>
+        <ol class="flex flex-wrap items-center gap-x-4 gap-y-1">
+          <li
+            v-for="h in leaders"
+            :key="h.rank"
+            class="flex items-baseline gap-2"
+          >
+            <span class="font-mono text-xs text-rose-300/60">#{{ h.rank }}</span>
+            <span class="font-semibold text-white">{{ h.hunterName }}</span>
+            <span v-if="h.hunterTable" class="text-xs text-gray-500">T{{ h.hunterTable }}</span>
+            <span class="font-mono text-xs text-amber-300">{{ h.totalPoints }}</span>
+          </li>
+        </ol>
+      </div>
+    </footer>
+  </main>
+</template>

--- a/apps/frontend/src/views/HuntModerateView.vue
+++ b/apps/frontend/src/views/HuntModerateView.vue
@@ -1,0 +1,551 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { apiFetch } from '@/lib/api'
+
+type ModPhoto = {
+  id: number
+  missionId: number
+  hunterToken: string
+  hunterName: string
+  hunterTable: string | null
+  thumbBase64: string
+  approved: boolean
+  createdAt: string
+}
+
+type Mission = {
+  id: number
+  position: number
+  title: string
+  description: string | null
+  example_thumb_base64: string | null
+  points: number
+  active: boolean
+  created_at: string
+}
+
+// Token kept in memory only — re-enter on refresh.
+const token = ref('')
+const authed = ref(false)
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const photos = ref<ModPhoto[]>([])
+const missions = ref<Mission[]>([])
+
+// Confirm modals
+const resetPhotosModal = ref(false)
+const resetAllModal = ref(false)
+const deletePhotoTarget = ref<ModPhoto | null>(null)
+const deleteMissionTarget = ref<Mission | null>(null)
+const busy = ref(false)
+
+// New / edit mission form state
+const editingMissionId = ref<number | null>(null)
+const formTitle = ref('')
+const formDescription = ref('')
+const formPoints = ref(10)
+const formActive = ref(true)
+
+const missionTitleById = computed(() => {
+  const m = new Map<number, string>()
+  for (const x of missions.value) m.set(x.id, x.title)
+  return m
+})
+
+function modHeaders(): HeadersInit {
+  return { 'Content-Type': 'application/json', 'x-mod-token': token.value }
+}
+
+async function loadAll() {
+  loading.value = true
+  error.value = null
+  try {
+    const [photosRes, missionsRes] = await Promise.all([
+      apiFetch('/api/hunt/photos/all', { headers: { 'x-mod-token': token.value } }),
+      apiFetch('/api/hunt/missions/all', { headers: { 'x-mod-token': token.value } }),
+    ])
+    if (photosRes.status === 401 || missionsRes.status === 401) {
+      error.value = 'Invalid moderator token.'
+      authed.value = false
+      return
+    }
+    const photosData = await photosRes.json().catch(() => ({}))
+    const missionsData = await missionsRes.json().catch(() => ({}))
+    if (!photosData?.success) throw new Error(photosData?.message || 'Failed to load photos')
+    if (!missionsData?.success) throw new Error(missionsData?.message || 'Failed to load missions')
+    photos.value = photosData.photos as ModPhoto[]
+    missions.value = missionsData.missions as Mission[]
+    authed.value = true
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to load'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function setApproved(photo: ModPhoto, approved: boolean) {
+  try {
+    const res = await apiFetch(`/api/hunt/photo/${photo.id}`, {
+      method: 'PATCH',
+      headers: modHeaders(),
+      body: JSON.stringify({ approved }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to update')
+    photo.approved = approved
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to update'
+  }
+}
+
+async function deletePhoto(photo: ModPhoto) {
+  busy.value = true
+  try {
+    const res = await apiFetch(`/api/hunt/photo/${photo.id}`, {
+      method: 'DELETE',
+      headers: { 'x-mod-token': token.value },
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to delete')
+    photos.value = photos.value.filter((p) => p.id !== photo.id)
+    deletePhotoTarget.value = null
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to delete'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function resetPhotos() {
+  busy.value = true
+  try {
+    const res = await apiFetch('/api/hunt/photos', {
+      method: 'DELETE',
+      headers: { 'x-mod-token': token.value },
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to reset')
+    photos.value = []
+    resetPhotosModal.value = false
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to reset'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function resetAll() {
+  busy.value = true
+  try {
+    const res = await apiFetch('/api/hunt/all', {
+      method: 'DELETE',
+      headers: { 'x-mod-token': token.value },
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to reset')
+    photos.value = []
+    missions.value = []
+    resetAllModal.value = false
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to reset'
+  } finally {
+    busy.value = false
+  }
+}
+
+// ─── Mission CRUD ───
+function startCreate() {
+  editingMissionId.value = null
+  formTitle.value = ''
+  formDescription.value = ''
+  formPoints.value = 10
+  formActive.value = true
+}
+function startEdit(m: Mission) {
+  editingMissionId.value = m.id
+  formTitle.value = m.title
+  formDescription.value = m.description ?? ''
+  formPoints.value = m.points
+  formActive.value = m.active
+}
+function cancelEdit() {
+  editingMissionId.value = null
+}
+
+async function saveMission() {
+  const title = formTitle.value.trim()
+  if (!title) return
+  busy.value = true
+  try {
+    const payload = {
+      title,
+      description: formDescription.value.trim() || undefined,
+      points: formPoints.value,
+      active: formActive.value,
+    }
+    const url = editingMissionId.value !== null
+      ? `/api/hunt/missions/${editingMissionId.value}`
+      : '/api/hunt/missions'
+    const method = editingMissionId.value !== null ? 'PATCH' : 'POST'
+    const res = await apiFetch(url, {
+      method,
+      headers: modHeaders(),
+      body: JSON.stringify(payload),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to save')
+    const saved = data.mission as Mission
+    if (editingMissionId.value !== null) {
+      const idx = missions.value.findIndex((m) => m.id === saved.id)
+      if (idx >= 0) missions.value[idx] = saved
+    } else {
+      missions.value = [...missions.value, saved].sort((a, b) => a.position - b.position || a.id - b.id)
+    }
+    startCreate()
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to save'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function toggleActive(m: Mission) {
+  try {
+    const res = await apiFetch(`/api/hunt/missions/${m.id}`, {
+      method: 'PATCH',
+      headers: modHeaders(),
+      body: JSON.stringify({ active: !m.active }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to toggle')
+    m.active = !m.active
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to toggle'
+  }
+}
+
+async function move(m: Mission, dir: -1 | 1) {
+  const sorted = [...missions.value].sort((a, b) => a.position - b.position || a.id - b.id)
+  const idx = sorted.findIndex((x) => x.id === m.id)
+  const swap = idx + dir
+  if (swap < 0 || swap >= sorted.length) return
+  ;[sorted[idx], sorted[swap]] = [sorted[swap]!, sorted[idx]!]
+  const orderedIds = sorted.map((x) => x.id)
+  try {
+    const res = await apiFetch('/api/hunt/missions/reorder', {
+      method: 'POST',
+      headers: modHeaders(),
+      body: JSON.stringify({ orderedIds }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to reorder')
+    // Refresh from server to get updated positions.
+    await loadAll()
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to reorder'
+  }
+}
+
+async function deleteMission(m: Mission) {
+  busy.value = true
+  try {
+    const res = await apiFetch(`/api/hunt/missions/${m.id}`, {
+      method: 'DELETE',
+      headers: { 'x-mod-token': token.value },
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to delete')
+    missions.value = missions.value.filter((x) => x.id !== m.id)
+    photos.value = photos.value.filter((p) => p.missionId !== m.id)
+    deleteMissionTarget.value = null
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to delete'
+  } finally {
+    busy.value = false
+  }
+}
+
+const photoApprovedCount = computed(() => photos.value.filter((p) => p.approved).length)
+const sortedMissions = computed(() => [...missions.value].sort((a, b) => a.position - b.position || a.id - b.id))
+</script>
+
+<template>
+  <main class="min-h-screen bg-off-white px-4 py-10">
+    <!-- ─── Confirm modals ─── -->
+    <Teleport to="body">
+      <div
+        v-if="resetPhotosModal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        @click.self="resetPhotosModal = false"
+      >
+        <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-7 shadow-xl">
+          <h2 class="text-xl font-bold text-gray-900">Wipe all hunt photos?</h2>
+          <p class="mt-3 text-sm leading-relaxed text-gray-600">
+            Deletes every photo submitted to the hunt. <strong>Missions are kept.</strong>
+            Use this to clear test photos before the real event. Cannot be undone.
+          </p>
+          <div class="mt-6 flex justify-end gap-3">
+            <button class="rounded-full border border-gray-300 px-5 py-2 text-sm text-gray-700 hover:bg-gray-50" :disabled="busy" @click="resetPhotosModal = false">Cancel</button>
+            <button class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50" :disabled="busy" @click="resetPhotos">{{ busy ? 'Wiping…' : 'Yes, wipe photos' }}</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div
+        v-if="resetAllModal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        @click.self="resetAllModal = false"
+      >
+        <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-7 shadow-xl">
+          <h2 class="text-xl font-bold text-gray-900">Reset all hunt data?</h2>
+          <p class="mt-3 text-sm leading-relaxed text-gray-600">
+            Deletes <strong>every photo AND every mission</strong>. To restore the default
+            mission list, run <code class="rounded bg-gray-100 px-1 py-0.5 text-xs">bun run db:seed:hunt</code>
+            on the backend.
+          </p>
+          <div class="mt-6 flex justify-end gap-3">
+            <button class="rounded-full border border-gray-300 px-5 py-2 text-sm text-gray-700 hover:bg-gray-50" :disabled="busy" @click="resetAllModal = false">Cancel</button>
+            <button class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50" :disabled="busy" @click="resetAll">{{ busy ? 'Resetting…' : 'Yes, reset everything' }}</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div
+        v-if="deletePhotoTarget"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        @click.self="deletePhotoTarget = null"
+      >
+        <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-7 shadow-xl">
+          <h2 class="text-xl font-bold text-gray-900">Delete this photo?</h2>
+          <p class="mt-3 text-sm text-gray-600">By <strong>{{ deletePhotoTarget?.hunterName }}</strong>. Cannot be undone.</p>
+          <div class="mt-6 flex justify-end gap-3">
+            <button class="rounded-full border border-gray-300 px-5 py-2 text-sm text-gray-700 hover:bg-gray-50" :disabled="busy" @click="deletePhotoTarget = null">Cancel</button>
+            <button class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50" :disabled="busy" @click="deletePhoto(deletePhotoTarget!)">{{ busy ? 'Deleting…' : 'Delete' }}</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div
+        v-if="deleteMissionTarget"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        @click.self="deleteMissionTarget = null"
+      >
+        <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-7 shadow-xl">
+          <h2 class="text-xl font-bold text-gray-900">Delete this mission?</h2>
+          <p class="mt-3 text-sm text-gray-600">
+            "{{ deleteMissionTarget?.title }}" — <strong>all photos for this mission will also be deleted</strong>.
+            Cannot be undone.
+          </p>
+          <div class="mt-6 flex justify-end gap-3">
+            <button class="rounded-full border border-gray-300 px-5 py-2 text-sm text-gray-700 hover:bg-gray-50" :disabled="busy" @click="deleteMissionTarget = null">Cancel</button>
+            <button class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50" :disabled="busy" @click="deleteMission(deleteMissionTarget!)">{{ busy ? 'Deleting…' : 'Yes, delete' }}</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- ─── Page ─── -->
+    <section class="mx-auto max-w-4xl">
+      <h1 class="font-cookie text-5xl text-rose-600">Mission Hunt Moderation</h1>
+      <p class="mt-2 text-gray-600">Photos, missions, and demo reset.</p>
+
+      <form v-if="!authed" class="mt-6 flex gap-3" @submit.prevent="loadAll">
+        <input
+          v-model="token"
+          type="password"
+          required
+          placeholder="Moderator token"
+          class="w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+        />
+        <button
+          type="submit"
+          :disabled="loading"
+          class="rounded-full bg-rose-600 px-6 py-2.5 text-white hover:bg-rose-700 disabled:opacity-50"
+        >{{ loading ? 'Loading…' : 'Enter' }}</button>
+      </form>
+
+      <p v-if="error" class="mt-4 text-rose-700">{{ error }}</p>
+
+      <template v-if="authed">
+        <!-- ─── Section 1: Photos ─── -->
+        <section class="mt-10">
+          <div class="flex items-center justify-between">
+            <h2 class="text-2xl font-semibold text-gray-900">Photos</h2>
+            <div class="flex gap-3">
+              <button class="text-sm text-rose-700 hover:underline" @click="loadAll">Refresh</button>
+              <button
+                class="rounded-full border border-red-300 px-4 py-1 text-sm text-red-600 hover:bg-red-50"
+                @click="resetPhotosModal = true"
+              >Reset photos</button>
+            </div>
+          </div>
+          <p class="mt-1 text-sm text-gray-500">
+            {{ photos.length }} total · {{ photoApprovedCount }} showing on the wall
+          </p>
+
+          <div v-if="photos.length === 0" class="mt-6 text-center text-gray-500">No photos yet.</div>
+
+          <div v-else class="mt-6 grid gap-3" style="grid-template-columns: repeat(auto-fill, minmax(180px, 1fr))">
+            <article
+              v-for="photo in photos"
+              :key="photo.id"
+              class="overflow-hidden rounded-2xl border bg-white shadow-sm"
+              :class="photo.approved ? 'border-gray-200' : 'border-red-200 opacity-60'"
+            >
+              <div class="aspect-square w-full bg-gray-100">
+                <img :src="photo.thumbBase64" :alt="photo.hunterName" class="h-full w-full object-cover" />
+              </div>
+              <div class="p-3">
+                <p class="truncate text-sm font-medium text-gray-900">{{ photo.hunterName }}</p>
+                <p class="truncate text-xs text-rose-600">{{ missionTitleById.get(photo.missionId) ?? `Mission #${photo.missionId}` }}</p>
+                <p class="text-xs text-gray-500">{{ new Date(photo.createdAt).toLocaleString() }}</p>
+                <div class="mt-2 flex justify-between gap-2">
+                  <button
+                    v-if="photo.approved"
+                    class="rounded-full bg-rose-50 px-3 py-1 text-xs text-rose-700 hover:bg-rose-100"
+                    @click="setApproved(photo, false)"
+                  >Hide</button>
+                  <button
+                    v-else
+                    class="rounded-full bg-green-50 px-3 py-1 text-xs text-green-700 hover:bg-green-100"
+                    @click="setApproved(photo, true)"
+                  >Restore</button>
+                  <button
+                    class="rounded-full border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50"
+                    @click="deletePhotoTarget = photo"
+                  >Delete</button>
+                </div>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <!-- ─── Section 2: Missions ─── -->
+        <section class="mt-12">
+          <h2 class="text-2xl font-semibold text-gray-900">Missions</h2>
+          <p class="mt-1 text-sm text-gray-500">Create, edit, reorder, hide, or delete.</p>
+
+          <!-- Create / edit form -->
+          <form
+            class="mt-5 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm space-y-4"
+            @submit.prevent="saveMission"
+          >
+            <p class="text-sm font-semibold text-gray-700">
+              {{ editingMissionId !== null ? `Editing mission #${editingMissionId}` : 'Add a new mission' }}
+            </p>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label class="block text-xs text-gray-600">Title</label>
+                <input
+                  v-model="formTitle"
+                  type="text"
+                  required
+                  maxlength="120"
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+                />
+              </div>
+              <div>
+                <label class="block text-xs text-gray-600">Points</label>
+                <input
+                  v-model.number="formPoints"
+                  type="number"
+                  min="1"
+                  max="999"
+                  required
+                  class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+                />
+              </div>
+            </div>
+            <div>
+              <label class="block text-xs text-gray-600">Description (optional)</label>
+              <textarea
+                v-model="formDescription"
+                rows="2"
+                maxlength="300"
+                class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+              />
+            </div>
+            <label class="flex items-center gap-2 text-sm text-gray-700">
+              <input v-model="formActive" type="checkbox" />
+              Active (shown to guests)
+            </label>
+            <div class="flex justify-end gap-3">
+              <button
+                v-if="editingMissionId !== null"
+                type="button"
+                class="rounded-full border border-gray-300 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                @click="cancelEdit"
+              >Cancel</button>
+              <button
+                type="submit"
+                :disabled="busy"
+                class="rounded-full bg-rose-600 px-5 py-1.5 text-sm text-white hover:bg-rose-700 disabled:opacity-50"
+              >{{ busy ? 'Saving…' : (editingMissionId !== null ? 'Save changes' : 'Add mission') }}</button>
+            </div>
+          </form>
+
+          <!-- Mission list -->
+          <div class="mt-5 space-y-2">
+            <article
+              v-for="(m, i) in sortedMissions"
+              :key="m.id"
+              class="flex items-center gap-3 rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm"
+              :class="!m.active ? 'opacity-60' : ''"
+            >
+              <div class="flex flex-col gap-0.5">
+                <button
+                  class="text-xs text-gray-400 hover:text-gray-700 disabled:opacity-30"
+                  :disabled="i === 0"
+                  @click="move(m, -1)"
+                  aria-label="Move up"
+                >▲</button>
+                <button
+                  class="text-xs text-gray-400 hover:text-gray-700 disabled:opacity-30"
+                  :disabled="i === sortedMissions.length - 1"
+                  @click="move(m, 1)"
+                  aria-label="Move down"
+                >▼</button>
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="truncate font-medium text-gray-900">{{ m.title }}</p>
+                <p v-if="m.description" class="truncate text-xs text-gray-500">{{ m.description }}</p>
+                <p class="text-xs text-gray-400">#{{ m.position }} · {{ m.points }} pts · {{ m.active ? 'active' : 'hidden' }}</p>
+              </div>
+              <div class="flex flex-shrink-0 gap-2">
+                <button class="rounded-full px-3 py-1 text-xs text-gray-600 hover:bg-gray-50" @click="toggleActive(m)">
+                  {{ m.active ? 'Hide' : 'Show' }}
+                </button>
+                <button class="rounded-full bg-rose-50 px-3 py-1 text-xs text-rose-700 hover:bg-rose-100" @click="startEdit(m)">Edit</button>
+                <button class="rounded-full border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50" @click="deleteMissionTarget = m">Delete</button>
+              </div>
+            </article>
+            <p v-if="sortedMissions.length === 0" class="text-center text-gray-500">No missions yet — add one above.</p>
+          </div>
+        </section>
+
+        <!-- ─── Section 3: Demo reset ─── -->
+        <section class="mt-12 rounded-2xl border border-red-200 bg-red-50/50 p-5">
+          <h2 class="text-xl font-semibold text-red-900">Danger zone</h2>
+          <p class="mt-1 text-sm text-red-800">Use during rehearsals; double-check before pressing during the event.</p>
+          <div class="mt-4 flex flex-wrap gap-3">
+            <button
+              class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700"
+              @click="resetPhotosModal = true"
+            >Reset photos only</button>
+            <button
+              class="rounded-full border border-red-600 px-5 py-2 text-sm text-red-700 hover:bg-red-100"
+              @click="resetAllModal = true"
+            >Reset everything (photos + missions)</button>
+          </div>
+        </section>
+      </template>
+    </section>
+  </main>
+</template>

--- a/apps/frontend/src/views/HuntView.vue
+++ b/apps/frontend/src/views/HuntView.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { apiFetch } from '@/lib/api'
+
+type Mission = {
+  id: number
+  position: number
+  title: string
+  description: string | null
+  example_thumb_base64: string | null
+  points: number
+  active: boolean
+}
+
+const route = useRoute()
+const router = useRouter()
+
+// ─── Identity (localStorage UUID + URL ?t= mirror, see spec for rationale) ───
+const HUNT_TOKEN_KEY = 'hunt_token_v1'
+const HUNT_NAME_KEY = 'hunt_name_v1'
+const HUNT_TABLE_KEY = 'hunt_table_v1'
+
+function safeGet(key: string): string | null {
+  try { return localStorage.getItem(key) } catch { return null }
+}
+function safeSet(key: string, value: string) {
+  try { localStorage.setItem(key, value) } catch { /* private mode */ }
+}
+
+function newToken(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+const hunterToken = ref('')
+const hunterName = ref('')
+const hunterTable = ref('')
+const onboarded = ref(false)
+
+const missions = ref<Mission[]>([])
+const completedMissionIds = ref<Set<number>>(new Set())
+const totalPoints = ref(0)
+
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const submittingMissionId = ref<number | null>(null)
+const successPing = ref<{ missionId: number; points: number } | null>(null)
+
+async function ensureDurableStorage() {
+  try {
+    if (navigator.storage?.persist) {
+      await navigator.storage.persist()
+    }
+  } catch { /* no-op */ }
+}
+
+function bootstrapIdentity() {
+  // 1. Token preference order: URL ?t= → localStorage → fresh.
+  const urlToken = typeof route.query.t === 'string' ? route.query.t : ''
+  const stored = safeGet(HUNT_TOKEN_KEY)
+  let token = urlToken || stored || newToken()
+  hunterToken.value = token
+  safeSet(HUNT_TOKEN_KEY, token)
+
+  // Mirror the token into the URL so clearing localStorage doesn't lose identity.
+  if (route.query.t !== token) {
+    router.replace({ query: { ...route.query, t: token } })
+  }
+
+  hunterName.value = safeGet(HUNT_NAME_KEY) ?? ''
+  hunterTable.value = safeGet(HUNT_TABLE_KEY) ?? ''
+  onboarded.value = hunterName.value.trim().length > 0
+}
+
+async function loadMissions() {
+  try {
+    const res = await apiFetch('/api/hunt/missions')
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to load missions')
+    missions.value = data.missions as Mission[]
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to load missions'
+  }
+}
+
+async function loadProgress() {
+  if (!hunterToken.value) return
+  try {
+    const res = await apiFetch(`/api/hunt/me?token=${encodeURIComponent(hunterToken.value)}`)
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) return
+    completedMissionIds.value = new Set<number>(data.completedMissionIds ?? [])
+    totalPoints.value = Number(data.totalPoints ?? 0)
+  } catch { /* silent */ }
+}
+
+function saveOnboarding() {
+  const name = hunterName.value.trim()
+  if (!name) return
+  safeSet(HUNT_NAME_KEY, name)
+  safeSet(HUNT_TABLE_KEY, hunterTable.value.trim())
+  onboarded.value = true
+}
+
+function changeIdentity() {
+  onboarded.value = false
+}
+
+// ─── Image compression (separate full + thumb passes) ───
+async function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const r = new FileReader()
+    r.onload = () => resolve(r.result as string)
+    r.onerror = () => reject(new Error('Could not read file'))
+    r.readAsDataURL(file)
+  })
+}
+
+async function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('Could not decode image'))
+    img.src = src
+  })
+}
+
+function downscale(img: HTMLImageElement, maxSize: number, quality: number): string {
+  const ratio = Math.min(1, maxSize / Math.max(img.width, img.height))
+  const w = Math.round(img.width * ratio)
+  const h = Math.round(img.height * ratio)
+  const c = document.createElement('canvas')
+  c.width = w
+  c.height = h
+  const ctx = c.getContext('2d')
+  if (!ctx) throw new Error('Canvas unavailable')
+  ctx.drawImage(img, 0, 0, w, h)
+  return c.toDataURL('image/jpeg', quality)
+}
+
+async function compressFile(file: File): Promise<{ full: string; thumb: string }> {
+  const url = await fileToDataUrl(file)
+  const img = await loadImage(url)
+  const full = downscale(img, 900, 0.82)
+  const thumb = downscale(img, 200, 0.78)
+  return { full, thumb }
+}
+
+async function onMissionFile(mission: Mission, event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+  if (!file) return
+  if (!file.type.startsWith('image/')) {
+    error.value = 'Please pick an image.'
+    return
+  }
+  if (!hunterName.value.trim()) {
+    error.value = 'Add your name first.'
+    return
+  }
+
+  submittingMissionId.value = mission.id
+  error.value = null
+  successPing.value = null
+  try {
+    const { full, thumb } = await compressFile(file)
+    const res = await apiFetch('/api/hunt/photo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        missionId: mission.id,
+        hunterToken: hunterToken.value,
+        hunterName: hunterName.value.trim(),
+        hunterTable: hunterTable.value.trim() || undefined,
+        thumbBase64: thumb,
+        fullBase64: full,
+      }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.success) {
+      throw new Error(data?.message || 'Upload failed')
+    }
+    if (!completedMissionIds.value.has(mission.id)) {
+      completedMissionIds.value = new Set([...completedMissionIds.value, mission.id])
+      totalPoints.value += Number(data.pointsAwarded ?? 0)
+    }
+    successPing.value = { missionId: mission.id, points: Number(data.pointsAwarded ?? 0) }
+    setTimeout(() => {
+      if (successPing.value?.missionId === mission.id) successPing.value = null
+    }, 4000)
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Upload failed'
+  } finally {
+    submittingMissionId.value = null
+  }
+}
+
+const completedCount = computed(() => completedMissionIds.value.size)
+const totalCount = computed(() => missions.value.length)
+
+onMounted(async () => {
+  bootstrapIdentity()
+  await ensureDurableStorage()
+  await loadMissions()
+  await loadProgress()
+  loading.value = false
+})
+</script>
+
+<template>
+  <main class="min-h-screen bg-off-white text-gray-800">
+    <section class="mx-auto max-w-2xl px-4 py-10 sm:py-14">
+      <header class="text-center">
+        <p class="text-xs uppercase tracking-[0.3em] text-rose-600">Som &amp; Pann · Wedding Activity</p>
+        <h1 class="font-cookie mt-2 text-5xl sm:text-6xl text-rose-600">Mission Hunt</h1>
+        <p class="mt-3 text-gray-600">
+          Snap photos that match each mission. The best shots show up on the big screen
+          throughout the night, and everyone's photos go into the wedding gallery.
+        </p>
+      </header>
+
+      <!-- Onboarding ───────────────────────────────────────────────── -->
+      <form
+        v-if="!onboarded"
+        class="mt-8 space-y-4 rounded-2xl border border-rose-100 bg-white p-6 shadow-sm"
+        @submit.prevent="saveOnboarding"
+      >
+        <div>
+          <label class="block text-sm font-medium text-gray-700" for="hunterName">Your name</label>
+          <input
+            id="hunterName"
+            v-model="hunterName"
+            type="text"
+            required
+            maxlength="80"
+            placeholder="What should we call you on the leaderboard?"
+            class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700" for="hunterTable">Table number <span class="text-gray-400">(optional)</span></label>
+          <input
+            id="hunterTable"
+            v-model="hunterTable"
+            type="text"
+            maxlength="20"
+            placeholder="e.g. 6"
+            class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          />
+          <p class="mt-1 text-xs text-gray-500">Helps tell two "Pim"s apart.</p>
+        </div>
+        <button
+          type="submit"
+          class="inline-flex items-center rounded-full bg-rose-600 px-6 py-2.5 text-white shadow hover:bg-rose-700"
+        >Start hunting</button>
+      </form>
+
+      <!-- Header strip when onboarded ─────────────────────────────── -->
+      <div v-else class="mt-8 rounded-2xl border border-rose-100 bg-white p-5 shadow-sm">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <p class="text-sm text-gray-500">Hunting as</p>
+            <p class="font-cookie text-2xl text-rose-600">
+              {{ hunterName }}<span v-if="hunterTable" class="text-base text-gray-500"> · table {{ hunterTable }}</span>
+            </p>
+          </div>
+          <div class="text-right">
+            <p class="text-sm text-gray-500">Score</p>
+            <p class="text-2xl font-semibold text-rose-600">{{ totalPoints }} pts</p>
+            <p class="text-xs text-gray-500">{{ completedCount }} / {{ totalCount }} missions</p>
+          </div>
+        </div>
+        <button class="mt-3 text-xs text-gray-500 hover:underline" @click="changeIdentity">Change name / table</button>
+      </div>
+
+      <p v-if="error" class="mt-4 text-rose-700 text-sm">{{ error }}</p>
+
+      <!-- Missions list ───────────────────────────────────────────── -->
+      <div v-if="loading" class="mt-8 text-center text-gray-500">Loading missions…</div>
+
+      <ol v-else-if="onboarded" class="mt-6 space-y-3">
+        <li
+          v-for="mission in missions"
+          :key="mission.id"
+          class="overflow-hidden rounded-2xl border bg-white shadow-sm"
+          :class="completedMissionIds.has(mission.id) ? 'border-green-300' : 'border-gray-200'"
+        >
+          <div class="flex items-stretch gap-4 p-4">
+            <div class="flex-shrink-0">
+              <div
+                v-if="mission.example_thumb_base64"
+                class="h-16 w-16 overflow-hidden rounded-lg bg-rose-50"
+              >
+                <img :src="mission.example_thumb_base64" class="h-full w-full object-cover" alt="example" />
+              </div>
+              <div
+                v-else
+                class="flex h-16 w-16 items-center justify-center rounded-lg bg-rose-50 font-cookie text-3xl text-rose-400"
+              >{{ mission.position }}</div>
+            </div>
+
+            <div class="flex-1">
+              <div class="flex items-start justify-between gap-2">
+                <h3 class="font-semibold text-gray-900">{{ mission.title }}</h3>
+                <span class="flex-shrink-0 rounded-full bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-700">{{ mission.points }} pts</span>
+              </div>
+              <p v-if="mission.description" class="mt-1 text-sm text-gray-600">{{ mission.description }}</p>
+
+              <div class="mt-3 flex items-center gap-3">
+                <label
+                  class="inline-flex cursor-pointer items-center rounded-full px-4 py-1.5 text-sm shadow-sm"
+                  :class="completedMissionIds.has(mission.id)
+                    ? 'bg-green-50 text-green-700 hover:bg-green-100'
+                    : 'bg-rose-600 text-white hover:bg-rose-700'"
+                >
+                  <span v-if="submittingMissionId === mission.id">Uploading…</span>
+                  <span v-else-if="completedMissionIds.has(mission.id)">✓ Done · take another</span>
+                  <span v-else>Take photo</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    capture="environment"
+                    class="hidden"
+                    :disabled="submittingMissionId !== null"
+                    @change="(e) => onMissionFile(mission, e)"
+                  />
+                </label>
+                <span
+                  v-if="successPing?.missionId === mission.id"
+                  class="text-xs text-green-700"
+                >+{{ successPing.points }} pts!</span>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ol>
+
+      <p v-if="onboarded && !loading && missions.length === 0" class="mt-8 text-center text-gray-500">
+        No missions are active right now. Check back later.
+      </p>
+
+      <p class="mt-10 text-xs text-gray-500">
+        Photos are shared with the couple and may appear on the projector. Be kind, be tasteful.
+      </p>
+    </section>
+  </main>
+</template>

--- a/apps/frontend/src/views/LotteryBoardView.vue
+++ b/apps/frontend/src/views/LotteryBoardView.vue
@@ -11,9 +11,9 @@ type DrawResult = {
 
 type Rank = 1 | 2 | 3
 const PRIZE_CONFIG: Record<Rank, { label: string; digits: number; accent: string }> = {
-  1: { label: '1st Prize', digits: 6, accent: '#f59e0b' },
-  2: { label: '2nd Prize', digits: 3, accent: '#e2e8f0' },
-  3: { label: '3rd Prize', digits: 2, accent: '#b45309' },
+  1: { label: 'รางวัลที่ 1', digits: 6, accent: '#f59e0b' },
+  2: { label: 'รางวัลที่ 2', digits: 3, accent: '#e2e8f0' },
+  3: { label: 'รางวัลที่ 3', digits: 2, accent: '#b45309' },
 }
 const cfg = (rank: number) => PRIZE_CONFIG[rank as Rank]
 
@@ -101,8 +101,8 @@ function getResult(rank: number): DrawResult | undefined {
 
 <template>
   <main class="min-h-screen bg-[#0b0c1a] text-white flex flex-col items-center justify-center px-4 py-12">
-    <h1 class="font-cookie text-5xl sm:text-7xl text-rose-400 mb-2 tracking-wide">Lucky Draw</h1>
-    <p class="text-gray-500 text-xs mb-10 tracking-widest uppercase">Som &amp; Pann Wedding</p>
+    <h1 class="font-cookie text-5xl sm:text-7xl text-rose-400 mb-2 tracking-wide">ลุ้นโชค</h1>
+    <p class="text-gray-500 text-xs mb-10 tracking-widest uppercase">งานแต่งงานส้ม &amp; ปัณณ์</p>
 
     <div class="w-full max-w-2xl space-y-6">
       <div
@@ -150,10 +150,10 @@ function getResult(rank: number): DrawResult | undefined {
               <span class="font-mono text-sm font-normal opacity-50">{{ w.number }}</span>
             </p>
           </div>
-          <p v-else class="text-gray-600 text-sm">No winner</p>
+          <p v-else class="text-gray-600 text-sm">ไม่มีผู้ถูกรางวัล</p>
         </template>
 
-        <div v-else class="text-gray-600 text-sm">Awaiting draw…</div>
+        <div v-else class="text-gray-600 text-sm">รอการจับรางวัล…</div>
       </div>
     </div>
   </main>

--- a/apps/frontend/src/views/LotteryModerateView.vue
+++ b/apps/frontend/src/views/LotteryModerateView.vue
@@ -12,9 +12,9 @@ type DrawResult = {
 
 type Rank = 1 | 2 | 3
 const PRIZE_CONFIG: Record<Rank, { label: string; digits: number }> = {
-  1: { label: '1st Prize', digits: 6 },
-  2: { label: '2nd Prize', digits: 3 },
-  3: { label: '3rd Prize', digits: 2 },
+  1: { label: 'รางวัลที่ 1', digits: 6 },
+  2: { label: 'รางวัลที่ 2', digits: 3 },
+  3: { label: 'รางวัลที่ 3', digits: 2 },
 }
 const cfg = (rank: number) => PRIZE_CONFIG[rank as Rank]
 
@@ -39,7 +39,7 @@ async function load() {
       apiFetch('/api/lottery/entries', { headers: { 'x-mod-token': token.value } }),
       apiFetch('/api/lottery/results'),
     ])
-    if (entryRes.status === 401) { error.value = 'Invalid moderator token.'; return }
+    if (entryRes.status === 401) { error.value = 'รหัสผู้ดูแลไม่ถูกต้อง'; return }
     const entryData = await entryRes.json().catch(() => ({}))
     const resultData = await resultRes.json().catch(() => ({}))
     if (!entryData.success) throw new Error(entryData.message || 'Failed to load entries')
@@ -131,30 +131,30 @@ const winnerNumbers = computed(() => {
         @click.self="fullResetModal = false"
       >
         <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-7 shadow-xl">
-          <h2 class="text-xl font-bold text-gray-900">Reset everything?</h2>
+          <h2 class="text-xl font-bold text-gray-900">รีเซ็ตทุกอย่าง?</h2>
           <p class="mt-3 text-gray-600 text-sm leading-relaxed">
-            This will permanently delete <strong>all registered numbers</strong> and <strong>all drawn prizes</strong>.
-            Use this only for demo purposes. This cannot be undone.
+            การดำเนินการนี้จะลบ <strong>หมายเลขที่ลงทะเบียนทั้งหมด</strong> และ <strong>รางวัลที่จับแล้วทั้งหมด</strong>
+            ใช้เฉพาะเพื่อสาธิตเท่านั้น ไม่สามารถยกเลิกได้
           </p>
           <div class="mt-6 flex justify-end gap-3">
             <button
               class="rounded-full border border-gray-300 px-5 py-2 text-sm text-gray-700 hover:bg-gray-50"
               :disabled="fullResetBusy"
               @click="fullResetModal = false"
-            >Cancel</button>
+            >ยกเลิก</button>
             <button
               class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
               :disabled="fullResetBusy"
               @click="fullReset"
-            >{{ fullResetBusy ? 'Resetting…' : 'Yes, delete everything' }}</button>
+            >{{ fullResetBusy ? 'กำลังรีเซ็ต…' : 'ใช่ ลบทั้งหมด' }}</button>
           </div>
         </div>
       </div>
     </Teleport>
 
     <section class="mx-auto max-w-4xl">
-      <h1 class="font-cookie text-5xl text-rose-600">Lottery Control Panel</h1>
-      <p class="mt-2 text-gray-500 text-sm">Draw prizes and see results. Use <code>/lottery/board</code> on the projector.</p>
+      <h1 class="font-cookie text-5xl text-rose-600">แผงควบคุมลอตเตอรี่</h1>
+      <p class="mt-2 text-gray-500 text-sm">จับรางวัลและดูผล ใช้ <code>/lottery/board</code> บนโปรเจคเตอร์</p>
 
       <!-- Auth -->
       <form v-if="!authed" class="mt-6 flex gap-3" @submit.prevent="load">
@@ -162,14 +162,14 @@ const winnerNumbers = computed(() => {
           v-model="token"
           type="password"
           required
-          placeholder="Moderator token"
+          placeholder="รหัสผู้ดูแล"
           class="w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
         />
         <button
           type="submit"
           :disabled="loading"
           class="rounded-full bg-rose-600 px-6 py-2.5 text-white hover:bg-rose-700 disabled:opacity-50"
-        >{{ loading ? 'Loading…' : 'Enter' }}</button>
+        >{{ loading ? 'กำลังโหลด…' : 'เข้าสู่ระบบ' }}</button>
       </form>
       <p v-if="error" class="mt-4 text-rose-700">{{ error }}</p>
 
@@ -178,20 +178,20 @@ const winnerNumbers = computed(() => {
         <!-- Draw controls -->
         <div>
           <div class="flex flex-wrap items-center justify-between gap-2 mb-4">
-            <h2 class="text-lg font-semibold text-gray-800">Prize Draw</h2>
+            <h2 class="text-lg font-semibold text-gray-800">จับรางวัล</h2>
             <div class="flex flex-wrap gap-2 items-center">
-              <button class="text-sm text-gray-500 hover:underline" @click="load">Refresh</button>
+              <button class="text-sm text-gray-500 hover:underline" @click="load">รีเฟรช</button>
               <template v-if="!resetDrawsConfirm">
-                <button class="text-sm text-rose-500 hover:underline" @click="resetDrawsConfirm = true">Reset draws</button>
+                <button class="text-sm text-rose-500 hover:underline" @click="resetDrawsConfirm = true">รีเซ็ตการจับรางวัล</button>
               </template>
               <template v-else>
-                <button class="text-sm text-rose-700 font-semibold hover:underline" @click="resetDraws">Confirm</button>
-                <button class="text-sm text-gray-500 hover:underline" @click="resetDrawsConfirm = false">Cancel</button>
+                <button class="text-sm text-rose-700 font-semibold hover:underline" @click="resetDraws">ยืนยัน</button>
+                <button class="text-sm text-gray-500 hover:underline" @click="resetDrawsConfirm = false">ยกเลิก</button>
               </template>
               <button
                 class="rounded-full border border-red-300 px-4 py-1 text-sm text-red-600 hover:bg-red-50"
                 @click="fullResetModal = true"
-              >Reset all (demo)</button>
+              >รีเซ็ตทั้งหมด (เดโม)</button>
             </div>
           </div>
 
@@ -204,7 +204,7 @@ const winnerNumbers = computed(() => {
               class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm text-center"
             >
               <p class="text-xs font-bold uppercase tracking-widest text-gray-400 mb-1">{{ cfg(rank).label }}</p>
-              <p class="text-xs text-gray-400 mb-3">{{ cfg(rank).digits }} digits</p>
+              <p class="text-xs text-gray-400 mb-3">{{ cfg(rank).digits }} หลัก</p>
 
               <template v-if="getResult(rank)">
                 <p class="font-mono text-3xl font-bold tracking-widest text-gray-900 mb-3">
@@ -215,7 +215,7 @@ const winnerNumbers = computed(() => {
                     🎉 {{ w.name }}
                   </p>
                 </div>
-                <p v-else class="text-gray-400 text-xs">No winner</p>
+                <p v-else class="text-gray-400 text-xs">ไม่มีผู้ถูกรางวัล</p>
               </template>
               <template v-else>
                 <p class="font-mono text-3xl font-bold tracking-widest text-gray-200 mb-3">
@@ -226,7 +226,7 @@ const winnerNumbers = computed(() => {
                   class="rounded-full bg-rose-600 px-4 py-2 text-sm text-white hover:bg-rose-700 disabled:opacity-50"
                   @click="draw(rank)"
                 >
-                  {{ drawing === rank ? 'Drawing…' : `Draw ${cfg(rank).label}` }}
+                  {{ drawing === rank ? 'กำลังจับ…' : `จับ${cfg(rank).label}` }}
                 </button>
               </template>
             </div>
@@ -236,8 +236,8 @@ const winnerNumbers = computed(() => {
         <!-- Entry list -->
         <div>
           <h2 class="text-base font-semibold text-gray-700 mb-3">
-            Registered numbers
-            <span class="ml-2 text-xs font-normal text-gray-400">({{ entries.length }} total)</span>
+            หมายเลขที่ลงทะเบียน
+            <span class="ml-2 text-xs font-normal text-gray-400">({{ entries.length }} รายการ)</span>
           </h2>
           <div class="flex flex-wrap gap-2">
             <div
@@ -251,7 +251,7 @@ const winnerNumbers = computed(() => {
               <span class="font-mono font-bold">{{ entry.number }}</span>
               <span class="ml-2 text-gray-500">{{ entry.name }}</span>
             </div>
-            <p v-if="entries.length === 0" class="text-gray-400 text-sm">No entries yet.</p>
+            <p v-if="entries.length === 0" class="text-gray-400 text-sm">ยังไม่มีผู้เข้าร่วม</p>
           </div>
         </div>
 

--- a/apps/frontend/src/views/LotteryView.vue
+++ b/apps/frontend/src/views/LotteryView.vue
@@ -38,12 +38,12 @@ async function submit() {
       body: JSON.stringify({ name: name.value.trim(), number: number.value.trim() }),
     })
     const data = await res.json().catch(() => ({}))
-    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to submit.')
-    success.value = `You're in the draw, ${name.value.trim()}! Good luck! 🍀`
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'ส่งข้อมูลไม่สำเร็จ กรุณาลองใหม่อีกครั้ง')
+    success.value = `${name.value.trim()} เข้าร่วมลุ้นโชคแล้ว! ขอให้โชคดี! 🍀`
     name.value = ''
     number.value = ''
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : 'Something went wrong.'
+    error.value = err instanceof Error ? err.message : 'เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง'
   } finally {
     loading.value = false
   }
@@ -53,35 +53,35 @@ async function submit() {
 <template>
   <main class="min-h-screen bg-off-white text-gray-800">
     <section class="mx-auto max-w-md px-4 py-12 sm:py-16">
-      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">Lucky Draw</h1>
-      <p class="mt-3 text-gray-600">Pick your lucky 6-digit number and join the draw at the reception!</p>
+      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">ลุ้นโชค</h1>
+      <p class="mt-3 text-gray-600">เลือกหมายเลข 6 หลักนำโชคของคุณ และร่วมลุ้นรับรางวัลในงาน!</p>
       <div class="mt-1 space-y-1">
-        <p class="text-sm text-rose-500 font-medium">Note: Numbers must not duplicate. Please check the used numbers below.</p>
-        <p class="text-sm text-rose-500 font-medium">Note: Each digit in your 6-digit number must be unique (no repeated digits).</p>
+        <p class="text-sm text-rose-500 font-medium">หมายเลขต้องไม่ซ้ำกับคนอื่น ตรวจสอบหมายเลขที่ถูกใช้แล้วด้านล่าง</p>
+        <p class="text-sm text-rose-500 font-medium">แต่ละหลักในหมายเลข 6 หลักต้องไม่ซ้ำกัน</p>
       </div>
 
       <div class="mt-6 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm text-sm text-gray-600 space-y-1">
-        <p><span class="font-semibold text-yellow-600">1st Prize</span> — exact 6-digit match</p>
-        <p><span class="font-semibold text-gray-500">2nd Prize</span> — last 3 digits match</p>
-        <p><span class="font-semibold text-amber-700">3rd Prize</span> — last 2 digits match</p>
-        <p class="pt-1 text-xs text-gray-400">Each number is unique — first come, first served.</p>
+        <p><span class="font-semibold text-yellow-600">รางวัลที่ 1</span> — ตรงทุก 6 หลัก</p>
+        <p><span class="font-semibold text-gray-500">รางวัลที่ 2</span> — 3 หลักท้ายตรง</p>
+        <p><span class="font-semibold text-amber-700">รางวัลที่ 3</span> — 2 หลักท้ายตรง</p>
+        <p class="pt-1 text-xs text-gray-400">แต่ละหมายเลขมีได้เพียงคนเดียว — มาก่อนได้ก่อน</p>
       </div>
 
       <form class="mt-8 space-y-5" @submit.prevent="submit">
         <div>
-          <label for="name" class="block text-sm font-medium text-gray-700">Your name</label>
+          <label for="name" class="block text-sm font-medium text-gray-700">ชื่อของคุณ</label>
           <input
             id="name"
             v-model="name"
             required
             type="text"
-            placeholder="As it should appear on screen"
+            placeholder="ชื่อที่จะแสดงบนจอ"
             class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
           />
         </div>
 
         <div>
-          <label class="block text-sm font-medium text-gray-700">Your lucky 6-digit number</label>
+          <label class="block text-sm font-medium text-gray-700">หมายเลขนำโชค 6 หลักของคุณ</label>
 
           <div class="mt-2 flex justify-between space-x-2 rounded-lg border border-gray-300 bg-gray-50 px-4 py-3 font-mono text-3xl tracking-[0.5em] shadow-inner">
             <span v-for="i in 6" :key="i" :class="number[i-1] ? 'text-gray-800' : 'text-gray-300'">
@@ -107,7 +107,7 @@ async function submit() {
               :disabled="number.length === 0"
               class="col-span-2 flex h-12 items-center justify-center rounded-lg border border-rose-200 bg-rose-50 text-sm font-medium text-rose-600 shadow-sm transition-all hover:bg-rose-100 active:bg-rose-200 disabled:opacity-50"
             >
-              Delete
+              ลบ
             </button>
             <button
               type="button"
@@ -115,12 +115,12 @@ async function submit() {
               :disabled="number.length === 0"
               class="col-span-3 flex h-12 items-center justify-center rounded-lg border border-gray-300 bg-gray-100 text-sm font-medium text-gray-600 shadow-sm transition-all hover:bg-gray-200 active:bg-gray-300 disabled:opacity-50"
             >
-              Clear All
+              ล้างทั้งหมด
             </button>
           </div>
 
           <p v-if="hasDuplicateDigits && number.length > 0" class="mt-2 text-xs text-rose-600">
-            Digits must not be repeated.
+            แต่ละหลักต้องไม่ซ้ำกัน
           </p>
         </div>
 
@@ -129,7 +129,7 @@ async function submit() {
           :disabled="loading || number.length !== 6 || hasDuplicateDigits"
           class="inline-flex items-center rounded-full bg-rose-600 px-6 py-3 text-white shadow hover:bg-rose-700 disabled:opacity-50"
         >
-          {{ loading ? 'Submitting…' : 'Join the draw' }}
+          {{ loading ? 'กำลังส่ง…' : 'ร่วมลุ้นโชค' }}
         </button>
       </form>
 

--- a/apps/frontend/src/views/MatchmakingBoardView.vue
+++ b/apps/frontend/src/views/MatchmakingBoardView.vue
@@ -43,8 +43,8 @@ onUnmounted(() => {
   <main class="min-h-screen bg-gradient-to-br from-rose-50 via-white to-rose-100 px-6 py-8">
     <header class="mb-8 text-center">
       <p class="text-sm uppercase tracking-[0.3em] text-rose-600">Kaywalee &amp; Supanat · Wedding Activity</p>
-      <h1 class="font-cookie mt-2 text-6xl sm:text-7xl text-rose-600">Matchmaking Corner</h1>
-      <p class="mt-2 text-gray-600">Meet our lovely single friends — say hi tonight!</p>
+      <h1 class="font-cookie mt-2 text-6xl sm:text-7xl text-rose-600">มุมจับคู่</h1>
+      <p class="mt-2 text-gray-600">มาทำความรู้จักเพื่อนโสดสุดน่ารักของเรากันเถอะ!</p>
     </header>
 
     <p v-if="error" class="mb-4 text-center text-rose-700">{{ error }}</p>
@@ -53,8 +53,8 @@ onUnmounted(() => {
       v-if="submissions.length === 0 && !error"
       class="flex min-h-[50vh] flex-col items-center justify-center text-center"
     >
-      <p class="font-cookie text-4xl text-rose-500">Submissions will appear here</p>
-      <p class="mt-2 text-gray-500">Scan the QR code to be the first to share a friend.</p>
+      <p class="font-cookie text-4xl text-rose-500">ข้อมูลจะปรากฏที่นี่</p>
+      <p class="mt-2 text-gray-500">สแกน QR Code เพื่อเป็นคนแรกที่แนะนำเพื่อน</p>
     </div>
 
     <section
@@ -84,7 +84,7 @@ onUnmounted(() => {
           <h2 class="font-cookie text-3xl leading-tight text-rose-600">{{ entry.friend_name }}</h2>
           <p v-if="entry.bio" class="text-sm text-gray-700">{{ entry.bio }}</p>
           <p class="mt-auto text-sm font-semibold text-rose-700 break-words">{{ entry.contact }}</p>
-          <p class="text-xs text-gray-500">Submitted by {{ entry.submitter_name }}</p>
+          <p class="text-xs text-gray-500">แนะนำโดย {{ entry.submitter_name }}</p>
         </div>
       </article>
     </section>

--- a/apps/frontend/src/views/MatchmakingBoardView.vue
+++ b/apps/frontend/src/views/MatchmakingBoardView.vue
@@ -84,7 +84,6 @@ onUnmounted(() => {
           <h2 class="font-cookie text-3xl leading-tight text-rose-600">{{ entry.friend_name }}</h2>
           <p v-if="entry.bio" class="text-sm text-gray-700">{{ entry.bio }}</p>
           <p class="mt-auto text-sm font-semibold text-rose-700 break-words">{{ entry.contact }}</p>
-          <p class="text-xs text-gray-500">แนะนำโดย {{ entry.submitter_name }}</p>
         </div>
       </article>
     </section>

--- a/apps/frontend/src/views/MatchmakingModerateView.vue
+++ b/apps/frontend/src/views/MatchmakingModerateView.vue
@@ -39,7 +39,7 @@ async function load() {
     submissions.value = data.submissions as Submission[]
     authed.value = true
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : 'Failed to load'
+    error.value = err instanceof Error ? err.message : 'ไม่สามารถโหลดข้อมูลได้'
   } finally {
     loading.value = false
   }
@@ -54,11 +54,11 @@ async function deleteAll() {
       headers: { 'x-mod-token': token.value },
     })
     const data = await res.json().catch(() => ({}))
-    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to delete')
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'ไม่สามารถลบข้อมูลได้')
     submissions.value = []
     deleteAllModal.value = false
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : 'Failed to delete'
+    error.value = err instanceof Error ? err.message : 'ไม่สามารถลบข้อมูลได้'
   } finally {
     deleteAllBusy.value = false
   }
@@ -72,11 +72,11 @@ async function setApproved(id: number, approved: boolean) {
       body: JSON.stringify({ approved }),
     })
     const data = await res.json().catch(() => ({}))
-    if (!res.ok || !data?.success) throw new Error(data?.message || 'Failed to update')
+    if (!res.ok || !data?.success) throw new Error(data?.message || 'ไม่สามารถอัปเดตข้อมูลได้')
     const entry = submissions.value.find((s) => s.id === id)
     if (entry) entry.approved = approved
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : 'Failed to update'
+    error.value = err instanceof Error ? err.message : 'ไม่สามารถอัปเดตข้อมูลได้'
   }
 }
 </script>
@@ -92,37 +92,37 @@ async function setApproved(id: number, approved: boolean) {
         @click.self="deleteAllModal = false"
       >
         <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-7 shadow-xl">
-          <h2 class="text-xl font-bold text-gray-900">Delete all submissions?</h2>
+          <h2 class="text-xl font-bold text-gray-900">ลบข้อมูลทั้งหมด?</h2>
           <p class="mt-3 text-gray-600 text-sm leading-relaxed">
-            This will permanently delete <strong>all matchmaking submissions</strong>.
-            Use this only for demo purposes. This cannot be undone.
+            การดำเนินการนี้จะลบ <strong>ข้อมูลมุมจับคู่ทั้งหมด</strong> อย่างถาวร
+            ใช้เฉพาะเพื่อสาธิตเท่านั้น ไม่สามารถยกเลิกได้
           </p>
           <div class="mt-6 flex justify-end gap-3">
             <button
               class="rounded-full border border-gray-300 px-5 py-2 text-sm text-gray-700 hover:bg-gray-50"
               :disabled="deleteAllBusy"
               @click="deleteAllModal = false"
-            >Cancel</button>
+            >ยกเลิก</button>
             <button
               class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
               :disabled="deleteAllBusy"
               @click="deleteAll"
-            >{{ deleteAllBusy ? 'Deleting…' : 'Yes, delete everything' }}</button>
+            >{{ deleteAllBusy ? 'กำลังลบ…' : 'ใช่ ลบทั้งหมด' }}</button>
           </div>
         </div>
       </div>
     </Teleport>
 
     <section class="mx-auto max-w-4xl">
-      <h1 class="font-cookie text-5xl text-rose-600">Matchmaking Moderation</h1>
-      <p class="mt-2 text-gray-600">Take down submissions before they show on the big screen.</p>
+      <h1 class="font-cookie text-5xl text-rose-600">จัดการมุมจับคู่</h1>
+      <p class="mt-2 text-gray-600">นำข้อมูลออกก่อนแสดงบนจอใหญ่</p>
 
       <form v-if="!authed" class="mt-6 flex gap-3" @submit.prevent="load">
         <input
           v-model="token"
           type="password"
           required
-          placeholder="Moderator token"
+          placeholder="รหัสผู้ดูแล"
           class="w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
         />
         <button
@@ -130,7 +130,7 @@ async function setApproved(id: number, approved: boolean) {
           :disabled="loading"
           class="rounded-full bg-rose-600 px-6 py-2.5 text-white hover:bg-rose-700 disabled:opacity-50"
         >
-          {{ loading ? 'Loading…' : 'Enter' }}
+          {{ loading ? 'กำลังโหลด…' : 'เข้าสู่ระบบ' }}
         </button>
       </form>
 
@@ -138,13 +138,13 @@ async function setApproved(id: number, approved: boolean) {
 
       <div v-if="authed" class="mt-8 space-y-4">
         <div class="flex items-center justify-between">
-          <p class="text-sm text-gray-500">{{ submissions.length }} total · {{ submissions.filter((s) => s.approved).length }} showing on screen</p>
+          <p class="text-sm text-gray-500">{{ submissions.length }} รายการ · แสดงบนจอ {{ submissions.filter((s) => s.approved).length }} รายการ</p>
           <div class="flex gap-3 items-center">
-            <button class="text-sm text-rose-700 hover:underline" @click="load">Refresh</button>
+            <button class="text-sm text-rose-700 hover:underline" @click="load">รีเฟรช</button>
             <button
               class="rounded-full border border-red-300 px-4 py-1 text-sm text-red-600 hover:bg-red-50"
               @click="deleteAllModal = true"
-            >Delete all (demo)</button>
+            >ลบทั้งหมด (เดโม)</button>
           </div>
         </div>
 
@@ -172,8 +172,8 @@ async function setApproved(id: number, approved: boolean) {
           <div class="flex-1">
             <h2 class="font-cookie text-3xl text-rose-600">{{ entry.friend_name }}</h2>
             <p v-if="entry.bio" class="mt-1 text-sm text-gray-700">{{ entry.bio }}</p>
-            <p class="mt-2 text-sm text-gray-700"><strong>Contact:</strong> {{ entry.contact }}</p>
-            <p class="text-xs text-gray-500">Submitted by {{ entry.submitter_name }} · {{ new Date(entry.created_at).toLocaleString() }}</p>
+            <p class="mt-2 text-sm text-gray-700"><strong>ช่องทางติดต่อ:</strong> {{ entry.contact }}</p>
+            <p class="text-xs text-gray-500">แนะนำโดย {{ entry.submitter_name }} · {{ new Date(entry.created_at).toLocaleString('th-TH') }}</p>
           </div>
 
           <div class="flex items-start">
@@ -182,19 +182,19 @@ async function setApproved(id: number, approved: boolean) {
               class="rounded-full bg-rose-50 px-4 py-2 text-sm text-rose-700 hover:bg-rose-100"
               @click="setApproved(entry.id, false)"
             >
-              Take down
+              นำออก
             </button>
             <button
               v-else
               class="rounded-full bg-green-50 px-4 py-2 text-sm text-green-700 hover:bg-green-100"
               @click="setApproved(entry.id, true)"
             >
-              Restore
+              คืนค่า
             </button>
           </div>
         </article>
 
-        <p v-if="submissions.length === 0" class="text-center text-gray-500">No submissions yet.</p>
+        <p v-if="submissions.length === 0" class="text-center text-gray-500">ยังไม่มีข้อมูล</p>
       </div>
     </section>
   </main>

--- a/apps/frontend/src/views/MatchmakingView.vue
+++ b/apps/frontend/src/views/MatchmakingView.vue
@@ -17,14 +17,14 @@ async function fileToDownscaledBase64(file: File, maxSize = 900, quality = 0.82)
   const dataUrl = await new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = () => resolve(reader.result as string)
-    reader.onerror = () => reject(new Error('Could not read file'))
+    reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'))
     reader.readAsDataURL(file)
   })
 
   const img = await new Promise<HTMLImageElement>((resolve, reject) => {
     const image = new Image()
     image.onload = () => resolve(image)
-    image.onerror = () => reject(new Error('Could not decode image'))
+    image.onerror = () => reject(new Error('ไม่สามารถโหลดรูปภาพได้'))
     image.src = dataUrl
   })
 
@@ -46,7 +46,7 @@ async function onFileChange(event: Event) {
   const file = input.files?.[0]
   if (!file) return
   if (!file.type.startsWith('image/')) {
-    errorMessage.value = 'Please select an image file.'
+    errorMessage.value = 'กรุณาเลือกไฟล์รูปภาพ'
     return
   }
   try {
@@ -56,7 +56,7 @@ async function onFileChange(event: Event) {
     errorMessage.value = null
   } catch (err) {
     console.error(err)
-    errorMessage.value = 'Could not read that image. Try another one.'
+    errorMessage.value = 'ไม่สามารถอ่านรูปภาพได้ กรุณาลองรูปอื่น'
   }
 }
 
@@ -91,15 +91,15 @@ async function submit() {
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok || !data?.success) {
-      throw new Error(data?.message || 'Failed to submit. Please try again.')
+      throw new Error(data?.message || 'ส่งข้อมูลไม่สำเร็จ กรุณาลองใหม่อีกครั้ง')
     }
-    successMessage.value = 'Thank you! Your pick is on its way to the big screen.'
+    successMessage.value = `ขอบคุณ! ข้อมูลของ ${friendName.value.trim()} กำลังขึ้นจอใหญ่แล้ว 🎉`
     resetForm()
   } catch (err: unknown) {
     if (err && typeof err === 'object' && 'message' in err && typeof (err as { message: unknown }).message === 'string') {
       errorMessage.value = (err as { message: string }).message
     } else {
-      errorMessage.value = 'Something went wrong. Please try again.'
+      errorMessage.value = 'เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง'
     }
   } finally {
     loading.value = false
@@ -110,67 +110,67 @@ async function submit() {
 <template>
   <main class="min-h-screen bg-off-white text-gray-800">
     <section class="mx-auto max-w-xl px-4 py-12 sm:py-16">
-      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">Matchmaking Corner</h1>
+      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">มุมจับคู่</h1>
       <p class="mt-3 text-gray-600">
-        Know a wonderful single friend? Tell us about them! We'll share the submissions on the big
-        screen at the reception so guests can meet.
+        รู้จักเพื่อนโสดดี ๆ ไหม? บอกเราเรื่องราวของพวกเขา!
+        เราจะแสดงรายชื่อบนจอใหญ่ที่งานแต่งงาน เผื่อใครสนใจทักทาย
       </p>
 
       <form class="mt-8 space-y-6" @submit.prevent="submit">
         <div>
-          <label for="submitterName" class="block text-sm font-medium text-gray-700">Your name</label>
+          <label for="submitterName" class="block text-sm font-medium text-gray-700">ชื่อของคุณ</label>
           <input
             id="submitterName"
             v-model="submitterName"
             required
             type="text"
-            placeholder="So your friend knows who sent them"
+            placeholder="เพื่อนจะได้รู้ว่าใครส่งมา"
             class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
           />
         </div>
 
         <div>
-          <label for="friendName" class="block text-sm font-medium text-gray-700">Your single friend's name</label>
+          <label for="friendName" class="block text-sm font-medium text-gray-700">ชื่อเพื่อนโสดของคุณ</label>
           <input
             id="friendName"
             v-model="friendName"
             required
             type="text"
-            placeholder="First name is fine"
+            placeholder="ชื่อเล่นก็ได้"
             class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
           />
         </div>
 
         <div>
-          <label for="contact" class="block text-sm font-medium text-gray-700">Contact</label>
+          <label for="contact" class="block text-sm font-medium text-gray-700">ช่องทางติดต่อ</label>
           <input
             id="contact"
             v-model="contact"
             required
             type="text"
-            placeholder="IG handle, LINE ID, or phone"
+            placeholder="IG, LINE ID หรือเบอร์โทร"
             class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
           />
         </div>
 
         <div>
-          <label for="bio" class="block text-sm font-medium text-gray-700">A short intro <span class="text-gray-400">(optional)</span></label>
+          <label for="bio" class="block text-sm font-medium text-gray-700">แนะนำตัวสั้น ๆ <span class="text-gray-400">(ไม่บังคับ)</span></label>
           <textarea
             id="bio"
             v-model="bio"
             rows="3"
             maxlength="500"
-            placeholder="Fun fact, what they're into, why they're a catch…"
+            placeholder="สิ่งที่น่าสนใจ งานอดิเรก หรือทำไมถึงน่าจีบ..."
             class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
           />
         </div>
 
         <div>
-          <label class="block text-sm font-medium text-gray-700">Photo <span class="text-gray-400">(optional)</span></label>
+          <label class="block text-sm font-medium text-gray-700">รูปภาพ <span class="text-gray-400">(ไม่บังคับ)</span></label>
           <div class="mt-2 flex items-center gap-4">
             <label class="inline-flex cursor-pointer items-center rounded-full bg-rose-50 px-4 py-2 text-sm text-rose-700 hover:bg-rose-100">
-              <span v-if="!photoPreview">Choose image</span>
-              <span v-else>Replace image</span>
+              <span v-if="!photoPreview">เลือกรูป</span>
+              <span v-else>เปลี่ยนรูป</span>
               <input type="file" accept="image/*" class="hidden" @change="onFileChange" />
             </label>
             <button
@@ -179,11 +179,11 @@ async function submit() {
               class="text-sm text-gray-500 hover:text-gray-700"
               @click="clearPhoto"
             >
-              Remove
+              ลบรูป
             </button>
           </div>
           <div v-if="photoPreview" class="mt-4">
-            <img :src="photoPreview" alt="Preview" class="max-h-64 rounded-lg object-cover shadow" />
+            <img :src="photoPreview" alt="ตัวอย่างรูป" class="max-h-64 rounded-lg object-cover shadow" />
           </div>
         </div>
 
@@ -192,8 +192,8 @@ async function submit() {
           :disabled="loading"
           class="inline-flex items-center rounded-full bg-rose-600 px-6 py-3 text-white shadow hover:bg-rose-700 disabled:opacity-50"
         >
-          <span v-if="!loading">Send to the big screen</span>
-          <span v-else>Sending…</span>
+          <span v-if="!loading">ส่งขึ้นจอใหญ่</span>
+          <span v-else>กำลังส่ง…</span>
         </button>
 
         <p v-if="successMessage" class="text-green-700">{{ successMessage }}</p>
@@ -201,8 +201,8 @@ async function submit() {
       </form>
 
       <p class="mt-10 text-sm text-gray-500">
-        By submitting, you confirm your friend is okay with being introduced at the wedding. Entries can
-        be taken down at any time by the moderators.
+        การส่งข้อมูล แสดงว่าคุณยืนยันว่าเพื่อนของคุณยินยอมให้แนะนำตัวในงานแต่งงาน
+        สามารถลบข้อมูลได้ตลอดเวลาโดยผู้ดูแล
       </p>
     </section>
   </main>


### PR DESCRIPTION
## Summary

- Translate all UI text and error messages to Thai across lottery and matchmaking views
- Lottery draw now picks from a distinct suffix pool of submitted numbers (true fair random for 2nd/3rd prize)
- Remove all string-distance / closest-match logic
- Add delete-all (demo reset) endpoint and confirmation modal in matchmaking moderate
- Hide submitter name on matchmaking board
- Add hunt feature: routes, views, DB migration, seed script

## Test plan

- [ ] Lottery: register numbers, draw each prize rank, verify winners shown correctly
- [ ] Lottery: duplicate number submission returns Thai 409 error
- [ ] Lottery board: digit-by-digit spin animation triggers on new draw
- [ ] Matchmaking: submit form, moderate panel approve/remove, board shows approved entries
- [ ] Matchmaking moderate: delete-all clears all entries
- [ ] Matchmaking board: submitter name not visible
- [ ] All UI text appears in Thai

🤖 Generated with [Claude Code](https://claude.com/claude-code)