### PR TITLE
fix: Sarabun fallback for Thai glyphs in font-cookie headings

### DIFF
--- a/apps/frontend/src/assets/main.css
+++ b/apps/frontend/src/assets/main.css
@@ -15,7 +15,7 @@
 
   --font-corinthia: "Corinthia", cursive;
   --font-fluer-de-leah: "Fleur De Leah", cursive;
-  --font-cookie: "Cookie", cursive;
+  --font-cookie: "Cookie", "Sarabun", cursive;
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

- Add `Sarabun` as fallback in `--font-cookie` definition
- Cookie font has no Thai glyphs — Thai characters in headings were falling back to system font instead of Sarabun

🤖 Generated with [Claude Code](https://claude.com/claude-code)