### PR TITLE
feat: Table Finder feature

### DIFF
--- a/apps/backend/src/db/migrations/0004_seats.sql
+++ b/apps/backend/src/db/migrations/0004_seats.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "seats" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "name" text NOT NULL,
+  "table_name" text NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL
+);

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777795200000,
       "tag": "0003_hunt",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778400000000,
+      "tag": "0004_seats",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -77,3 +77,13 @@ export const huntPhotos = pgTable('hunt_photos', {
 
 export type InsertHuntPhoto = typeof huntPhotos.$inferInsert;
 export type SelectHuntPhoto = typeof huntPhotos.$inferSelect;
+
+export const seats = pgTable('seats', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  tableName: text('table_name').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type InsertSeat = typeof seats.$inferInsert;
+export type SelectSeat = typeof seats.$inferSelect;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -8,6 +8,7 @@ import { rsvpRoutes } from './routes/rsvp';
 import { matchmakingRoutes } from './routes/matchmaking';
 import { lotteryRoutes } from './routes/lottery';
 import { huntRoutes } from './routes/hunt';
+import { seatsRoutes } from './routes/seats';
 
 const dbHealthCheck = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -36,6 +37,7 @@ const app = new Elysia()
   .use(matchmakingRoutes)
   .use(lotteryRoutes)
   .use(huntRoutes)
+  .use(seatsRoutes)
   .listen(3000);
 
 Effect.runPromise(dbHealthCheck)

--- a/apps/backend/src/routes/seats.ts
+++ b/apps/backend/src/routes/seats.ts
@@ -1,0 +1,141 @@
+import { Elysia, t } from 'elysia';
+import { Effect } from 'effect';
+import { SqlClient } from '@effect/sql';
+import { LiveDatabase } from '../db';
+import { requireModToken } from '../lib/auth';
+
+export const seatsRoutes = new Elysia()
+
+  // Public: search by name
+  .get('/api/seats', async ({ query, set }) => {
+    const q = (query.q ?? '').trim();
+    if (!q) return { success: true, seats: [] };
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<{ id: number; name: string; table_name: string }>`
+            SELECT id, name, table_name
+            FROM seats
+            WHERE name ILIKE ${'%' + q + '%'}
+            ORDER BY name ASC
+            LIMIT 20
+          `;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true, seats: rows };
+    } catch {
+      set.status = 500;
+      return { success: false, message: 'ไม่สามารถค้นหาได้' };
+    }
+  }, { query: t.Object({ q: t.Optional(t.String()) }) })
+
+  // Mod: list all
+  .get('/api/seats/all', async ({ headers, set }) => {
+    const auth = requireModToken(headers, set);
+    if (auth) return auth;
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<{ id: number; name: string; table_name: string }>`
+            SELECT id, name, table_name FROM seats ORDER BY table_name ASC, name ASC
+          `;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true, seats: rows };
+    } catch {
+      set.status = 500;
+      return { success: false, message: 'ไม่สามารถโหลดข้อมูลได้' };
+    }
+  })
+
+  // Mod: add single seat
+  .post('/api/seats', async ({ body, headers, set }) => {
+    const auth = requireModToken(headers, set);
+    if (auth) return auth;
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<{ id: number; name: string; table_name: string }>`
+            INSERT INTO seats (name, table_name) VALUES (${body.name.trim()}, ${body.table_name.trim()})
+            RETURNING id, name, table_name
+          `;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true, seat: rows[0] };
+    } catch {
+      set.status = 500;
+      return { success: false, message: 'ไม่สามารถบันทึกข้อมูลได้' };
+    }
+  }, {
+    body: t.Object({
+      name: t.String({ minLength: 1, maxLength: 200 }),
+      table_name: t.String({ minLength: 1, maxLength: 50 }),
+    }),
+  })
+
+  // Mod: update single seat
+  .patch('/api/seats/:id', async ({ params, body, headers, set }) => {
+    const auth = requireModToken(headers, set);
+    if (auth) return auth;
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          return yield* sql<{ id: number; name: string; table_name: string }>`
+            UPDATE seats SET name = ${body.name.trim()}, table_name = ${body.table_name.trim()}
+            WHERE id = ${Number(params.id)}
+            RETURNING id, name, table_name
+          `;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      if (!rows.length) { set.status = 404; return { success: false, message: 'ไม่พบข้อมูล' }; }
+      return { success: true, seat: rows[0] };
+    } catch {
+      set.status = 500;
+      return { success: false, message: 'ไม่สามารถอัปเดตข้อมูลได้' };
+    }
+  }, {
+    body: t.Object({
+      name: t.String({ minLength: 1, maxLength: 200 }),
+      table_name: t.String({ minLength: 1, maxLength: 50 }),
+    }),
+  })
+
+  // Mod: delete single seat
+  .delete('/api/seats/:id', async ({ params, headers, set }) => {
+    const auth = requireModToken(headers, set);
+    if (auth) return auth;
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`DELETE FROM seats WHERE id = ${Number(params.id)}`;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true };
+    } catch {
+      set.status = 500;
+      return { success: false, message: 'ไม่สามารถลบข้อมูลได้' };
+    }
+  })
+
+  // Mod: delete all seats
+  .delete('/api/seats', async ({ headers, set }) => {
+    const auth = requireModToken(headers, set);
+    if (auth) return auth;
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`DELETE FROM seats`;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true };
+    } catch {
+      set.status = 500;
+      return { success: false, message: 'ไม่สามารถลบข้อมูลได้' };
+    }
+  });

--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -25,6 +25,9 @@ const showHeader = computed(() => route.name !== 'landing')
           <RouterLink class="text-gray-600 hover:text-gray-900" to="/gallery">
             Gallery
           </RouterLink>
+          <RouterLink class="text-gray-600 hover:text-gray-900" to="/table">
+            โต๊ะ
+          </RouterLink>
           <RouterLink class="text-gray-600 hover:text-gray-900" to="/lottery">
             Lucky Draw
           </RouterLink>

--- a/apps/frontend/src/router/index.ts
+++ b/apps/frontend/src/router/index.ts
@@ -82,9 +82,18 @@ const router = createRouter({
       name: 'hunt-moderate',
       component: () => import('../views/HuntModerateView.vue'),
     },
+    {
+      path: '/table',
+      name: 'table',
+      component: () => import('../views/TableView.vue'),
+    },
+    {
+      path: '/table/moderate',
+      name: 'table-moderate',
+      component: () => import('../views/TableModerateView.vue'),
+    },
     // todo add video presentation
     // todo pre wedding photo
-    // todo seat plan
   ],
 })
 

--- a/apps/frontend/src/views/TableModerateView.vue
+++ b/apps/frontend/src/views/TableModerateView.vue
@@ -1,0 +1,285 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { apiFetch } from '@/lib/api'
+
+type Seat = { id: number; name: string; table_name: string }
+
+const token = ref('')
+const authed = ref(false)
+const loading = ref(false)
+const error = ref<string | null>(null)
+const seats = ref<Seat[]>([])
+
+// Add form
+const addName = ref('')
+const addTable = ref('')
+const addBusy = ref(false)
+
+// Edit state: id → draft values
+const editId = ref<number | null>(null)
+const editName = ref('')
+const editTable = ref('')
+const editBusy = ref(false)
+
+// Delete all modal
+const deleteAllModal = ref(false)
+const deleteAllBusy = ref(false)
+
+// Filter
+const filterQ = ref('')
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await apiFetch('/api/seats/all', { headers: { 'x-mod-token': token.value } })
+    const data = await res.json().catch(() => ({}))
+    if (res.status === 401) { error.value = 'รหัสผู้ดูแลไม่ถูกต้อง'; return }
+    if (!data.success) throw new Error(data.message || 'โหลดข้อมูลไม่สำเร็จ')
+    seats.value = data.seats as Seat[]
+    authed.value = true
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'โหลดข้อมูลไม่สำเร็จ'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function addSeat() {
+  if (!addName.value.trim() || !addTable.value.trim()) return
+  addBusy.value = true
+  error.value = null
+  try {
+    const res = await apiFetch('/api/seats', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-mod-token': token.value },
+      body: JSON.stringify({ name: addName.value.trim(), table_name: addTable.value.trim() }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data.success) throw new Error(data.message || 'บันทึกไม่สำเร็จ')
+    seats.value.push(data.seat as Seat)
+    addName.value = ''
+    addTable.value = ''
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'บันทึกไม่สำเร็จ'
+  } finally {
+    addBusy.value = false
+  }
+}
+
+function startEdit(seat: Seat) {
+  editId.value = seat.id
+  editName.value = seat.name
+  editTable.value = seat.table_name
+}
+
+function cancelEdit() {
+  editId.value = null
+}
+
+async function saveEdit(seat: Seat) {
+  if (!editName.value.trim() || !editTable.value.trim()) return
+  editBusy.value = true
+  error.value = null
+  try {
+    const res = await apiFetch(`/api/seats/${seat.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'x-mod-token': token.value },
+      body: JSON.stringify({ name: editName.value.trim(), table_name: editTable.value.trim() }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data.success) throw new Error(data.message || 'อัปเดตไม่สำเร็จ')
+    const idx = seats.value.findIndex(s => s.id === seat.id)
+    if (idx !== -1) seats.value[idx] = data.seat as Seat
+    editId.value = null
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'อัปเดตไม่สำเร็จ'
+  } finally {
+    editBusy.value = false
+  }
+}
+
+async function deleteSeat(id: number) {
+  try {
+    const res = await apiFetch(`/api/seats/${id}`, {
+      method: 'DELETE',
+      headers: { 'x-mod-token': token.value },
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data.success) throw new Error(data.message || 'ลบไม่สำเร็จ')
+    seats.value = seats.value.filter(s => s.id !== id)
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'ลบไม่สำเร็จ'
+  }
+}
+
+async function deleteAll() {
+  deleteAllBusy.value = true
+  error.value = null
+  try {
+    const res = await apiFetch('/api/seats', {
+      method: 'DELETE',
+      headers: { 'x-mod-token': token.value },
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data.success) throw new Error(data.message || 'ลบไม่สำเร็จ')
+    seats.value = []
+    deleteAllModal.value = false
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'ลบไม่สำเร็จ'
+  } finally {
+    deleteAllBusy.value = false
+  }
+}
+
+const filtered = () =>
+  filterQ.value.trim()
+    ? seats.value.filter(s =>
+        s.name.toLowerCase().includes(filterQ.value.toLowerCase()) ||
+        s.table_name.toLowerCase().includes(filterQ.value.toLowerCase())
+      )
+    : seats.value
+</script>
+
+<template>
+  <main class="min-h-screen bg-off-white px-4 py-10 text-gray-800">
+
+    <!-- Delete All Modal -->
+    <Teleport to="body">
+      <div
+        v-if="deleteAllModal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        @click.self="deleteAllModal = false"
+      >
+        <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-7 shadow-xl">
+          <h2 class="text-xl font-bold text-gray-900">ลบข้อมูลทั้งหมด?</h2>
+          <p class="mt-3 text-sm text-gray-600 leading-relaxed">
+            จะลบ <strong>ที่นั่งแขกทั้งหมด</strong> อย่างถาวร ไม่สามารถยกเลิกได้
+          </p>
+          <div class="mt-6 flex justify-end gap-3">
+            <button
+              class="rounded-full border border-gray-300 px-5 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              :disabled="deleteAllBusy"
+              @click="deleteAllModal = false"
+            >ยกเลิก</button>
+            <button
+              class="rounded-full bg-red-600 px-5 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+              :disabled="deleteAllBusy"
+              @click="deleteAll"
+            >{{ deleteAllBusy ? 'กำลังลบ…' : 'ใช่ ลบทั้งหมด' }}</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <section class="mx-auto max-w-3xl">
+      <h1 class="font-cookie text-5xl text-rose-600">จัดการที่นั่ง</h1>
+      <p class="mt-2 text-gray-500 text-sm">เพิ่ม แก้ไข หรือลบรายชื่อแขกและโต๊ะ</p>
+
+      <!-- Auth form -->
+      <form v-if="!authed" class="mt-6 flex gap-3" @submit.prevent="load">
+        <input
+          v-model="token"
+          type="password"
+          required
+          placeholder="รหัสผู้ดูแล"
+          class="w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+        />
+        <button
+          type="submit"
+          :disabled="loading"
+          class="rounded-full bg-rose-600 px-6 py-2.5 text-white hover:bg-rose-700 disabled:opacity-50"
+        >{{ loading ? 'กำลังโหลด…' : 'เข้าสู่ระบบ' }}</button>
+      </form>
+
+      <p v-if="error" class="mt-4 text-rose-700 text-sm">{{ error }}</p>
+
+      <div v-if="authed" class="mt-8 space-y-6">
+
+        <!-- Add row form -->
+        <div class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <h2 class="text-sm font-semibold text-gray-700 mb-3">เพิ่มแขก</h2>
+          <form class="flex gap-2 flex-wrap" @submit.prevent="addSeat">
+            <input
+              v-model="addName"
+              type="text"
+              required
+              placeholder="ชื่อแขก"
+              class="flex-1 min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+            />
+            <input
+              v-model="addTable"
+              type="text"
+              required
+              placeholder="โต๊ะ (เช่น 5, A, VIP)"
+              class="w-36 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+            />
+            <button
+              type="submit"
+              :disabled="addBusy"
+              class="rounded-full bg-rose-600 px-5 py-2 text-sm text-white hover:bg-rose-700 disabled:opacity-50"
+            >{{ addBusy ? 'กำลังบันทึก…' : 'เพิ่ม' }}</button>
+          </form>
+        </div>
+
+        <!-- Header row -->
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <div class="flex items-center gap-3">
+            <p class="text-sm text-gray-500">{{ seats.length }} รายการ</p>
+            <input
+              v-model="filterQ"
+              type="text"
+              placeholder="กรองรายชื่อ…"
+              class="rounded-lg border border-gray-200 px-3 py-1.5 text-sm focus:border-rose-400 focus:outline-none"
+            />
+          </div>
+          <div class="flex gap-3">
+            <button class="text-sm text-gray-500 hover:underline" @click="load">รีเฟรช</button>
+            <button
+              class="rounded-full border border-red-300 px-4 py-1 text-sm text-red-600 hover:bg-red-50"
+              @click="deleteAllModal = true"
+            >ลบทั้งหมด (เดโม)</button>
+          </div>
+        </div>
+
+        <!-- Seat list -->
+        <div class="space-y-2">
+          <div
+            v-for="seat in filtered()"
+            :key="seat.id"
+            class="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm"
+          >
+            <template v-if="editId === seat.id">
+              <input
+                v-model="editName"
+                class="flex-1 min-w-0 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-200"
+                @keydown.enter.prevent="saveEdit(seat)"
+                @keydown.escape="cancelEdit"
+              />
+              <input
+                v-model="editTable"
+                class="w-28 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-200"
+                @keydown.enter.prevent="saveEdit(seat)"
+                @keydown.escape="cancelEdit"
+              />
+              <button
+                class="text-sm text-green-700 hover:underline"
+                :disabled="editBusy"
+                @click="saveEdit(seat)"
+              >บันทึก</button>
+              <button class="text-sm text-gray-400 hover:underline" @click="cancelEdit">ยกเลิก</button>
+            </template>
+            <template v-else>
+              <p class="flex-1 text-sm text-gray-800">{{ seat.name }}</p>
+              <p class="font-cookie text-2xl text-rose-600 w-16 text-right">{{ seat.table_name }}</p>
+              <button class="text-xs text-gray-400 hover:text-gray-700" @click="startEdit(seat)">แก้ไข</button>
+              <button class="text-xs text-red-400 hover:text-red-600" @click="deleteSeat(seat.id)">ลบ</button>
+            </template>
+          </div>
+          <p v-if="filtered().length === 0" class="text-center text-sm text-gray-400 py-6">ไม่มีรายการ</p>
+        </div>
+
+      </div>
+    </section>
+  </main>
+</template>

--- a/apps/frontend/src/views/TableView.vue
+++ b/apps/frontend/src/views/TableView.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { apiFetch } from '@/lib/api'
+
+type Seat = { id: number; name: string; table_name: string }
+
+const query = ref('')
+const seats = ref<Seat[]>([])
+const loading = ref(false)
+const searched = ref(false)
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+function onInput() {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  if (!query.value.trim()) {
+    seats.value = []
+    searched.value = false
+    return
+  }
+  debounceTimer = setTimeout(search, 350)
+}
+
+async function search() {
+  if (!query.value.trim()) return
+  loading.value = true
+  searched.value = true
+  try {
+    const res = await apiFetch(`/api/seats?q=${encodeURIComponent(query.value.trim())}`)
+    const data = await res.json().catch(() => ({}))
+    seats.value = data.seats ?? []
+  } catch {
+    seats.value = []
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <main class="min-h-screen bg-off-white text-gray-800">
+    <section class="mx-auto max-w-md px-4 py-12 sm:py-16">
+      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">ค้นหาโต๊ะของคุณ</h1>
+      <p class="mt-3 text-gray-600">พิมพ์ชื่อเพื่อดูหมายเลขโต๊ะของคุณ</p>
+
+      <div class="mt-8">
+        <input
+          v-model="query"
+          @input="onInput"
+          @keydown.enter.prevent="search"
+          type="text"
+          placeholder="ชื่อ-นามสกุล"
+          class="w-full rounded-lg border border-gray-300 px-4 py-3 text-lg shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+        />
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="mt-8 text-center text-gray-500">กำลังค้นหา…</div>
+
+      <!-- Results -->
+      <div v-else-if="seats.length" class="mt-6 space-y-3">
+        <div
+          v-for="seat in seats"
+          :key="seat.id"
+          class="flex items-center justify-between rounded-2xl border border-rose-100 bg-white px-5 py-4 shadow-sm"
+        >
+          <p class="text-gray-800 font-medium">{{ seat.name }}</p>
+          <div class="text-right">
+            <p class="text-xs text-gray-400 uppercase tracking-widest">โต๊ะ</p>
+            <p class="font-cookie text-3xl text-rose-600 leading-none">{{ seat.table_name }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- No result -->
+      <div v-else-if="searched && !loading" class="mt-8 text-center text-gray-500">
+        <p class="text-lg">ไม่พบชื่อ "{{ query }}"</p>
+        <p class="mt-2 text-sm">ลองค้นหาด้วยชื่อภาษาอื่น หรือติดต่อเจ้าหน้าที่</p>
+      </div>
+    </section>
+  </main>
+</template>


### PR DESCRIPTION
## Summary

- New `seats` table + migration `0004_seats.sql`
- Backend: search by name (`ILIKE`), add, inline-edit, delete one/all — mod auth on writes
- `TableView`: debounced search, result cards showing table name
- `TableModerateView`: web CRUD — add form, inline edit, per-row delete, filter, delete-all modal
- Router: `/table` + `/table/moderate`
- Nav: โต๊ะ link added

## Test plan

- [ ] Guest searches name → correct table shown
- [ ] No result message shown when name not found
- [ ] Mod can add, edit, delete entries
- [ ] Delete-all modal works
- [ ] Filter narrows list correctly
- [ ] Run `db:migrate` on server before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)