### PR TITLE
feat: seats CSV import, wider layouts, nav/UI polish

### DIFF
--- a/apps/backend/src/routes/seats.ts
+++ b/apps/backend/src/routes/seats.ts
@@ -122,6 +122,43 @@ export const seatsRoutes = new Elysia()
     }
   })
 
+  // Mod: import from CSV (overwrite all)
+  .post('/api/seats/import', async ({ body, headers, set }) => {
+    const auth = requireModToken(headers, set);
+    if (auth) return auth;
+    const rows = body.rows;
+    if (!rows.length) { set.status = 400; return { success: false, message: 'ไม่มีข้อมูลที่จะนำเข้า' }; }
+    try {
+      const inserted = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`DELETE FROM seats`;
+          const results: { id: number; name: string; table_name: string }[] = [];
+          for (const row of rows) {
+            const r = yield* sql<{ id: number; name: string; table_name: string }>`
+              INSERT INTO seats (name, table_name) VALUES (${row.name.trim()}, ${row.table_name.trim()})
+              RETURNING id, name, table_name
+            `;
+            if (r[0]) results.push(r[0]);
+          }
+          return results;
+        }).pipe(Effect.provide(LiveDatabase))
+      );
+      return { success: true, count: inserted.length, seats: inserted };
+    } catch (err) {
+      console.error('import error', err);
+      set.status = 500;
+      return { success: false, message: 'นำเข้าข้อมูลไม่สำเร็จ' };
+    }
+  }, {
+    body: t.Object({
+      rows: t.Array(t.Object({
+        name: t.String({ minLength: 1, maxLength: 200 }),
+        table_name: t.String({ minLength: 1, maxLength: 50 }),
+      }), { minItems: 1 }),
+    }),
+  })
+
   // Mod: delete all seats
   .delete('/api/seats', async ({ headers, set }) => {
     const auth = requireModToken(headers, set);

--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -26,7 +26,7 @@ const showHeader = computed(() => route.name !== 'landing')
             Gallery
           </RouterLink>
           <RouterLink class="text-gray-600 hover:text-gray-900" to="/table">
-            โต๊ะ
+            Table
           </RouterLink>
           <RouterLink class="text-gray-600 hover:text-gray-900" to="/lottery">
             Lucky Draw

--- a/apps/frontend/src/views/LotteryView.vue
+++ b/apps/frontend/src/views/LotteryView.vue
@@ -52,7 +52,7 @@ async function submit() {
 
 <template>
   <main class="min-h-screen bg-off-white text-gray-800">
-    <section class="mx-auto max-w-md px-4 py-12 sm:py-16">
+    <section class="mx-auto max-w-2xl px-4 py-12 sm:py-16">
       <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">สลากกินไม่แบ่ง กินอยู่คนเดียว</h1>
       <p class="mt-3 text-gray-600">เลือกหมายเลข 6 หลักนำโชคของคุณ และร่วมลุ้นรับรางวัลในงาน!</p>
       <div class="mt-1 space-y-1">

--- a/apps/frontend/src/views/MatchmakingView.vue
+++ b/apps/frontend/src/views/MatchmakingView.vue
@@ -109,7 +109,7 @@ async function submit() {
 
 <template>
   <main class="min-h-screen bg-off-white text-gray-800">
-    <section class="mx-auto max-w-xl px-4 py-12 sm:py-16">
+    <section class="mx-auto max-w-2xl px-4 py-12 sm:py-16">
       <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">มุมคนโสดโดยความสามารถ</h1>
       <p class="mt-3 text-gray-600">
         รู้จักเพื่อนโสดดี ๆ ไหม? บอกเราเรื่องราวของพวกเขา!

--- a/apps/frontend/src/views/TableModerateView.vue
+++ b/apps/frontend/src/views/TableModerateView.vue
@@ -28,6 +28,65 @@ const deleteAllBusy = ref(false)
 // Filter
 const filterQ = ref('')
 
+// CSV import
+const csvPreview = ref<{ name: string; table_name: string }[]>([])
+const csvError = ref<string | null>(null)
+const importBusy = ref(false)
+const importSuccess = ref<string | null>(null)
+
+function parseCSV(text: string): { name: string; table_name: string }[] {
+  const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean)
+  const rows: { name: string; table_name: string }[] = []
+  for (const line of lines) {
+    // skip header row if it looks like "name,table" literally
+    if (/^name[,;]/i.test(line)) continue
+    const sep = line.includes(';') ? ';' : ','
+    const parts = line.split(sep).map(p => p.trim().replace(/^"|"$/g, ''))
+    if (parts.length < 2 || !parts[0] || !parts[1]) continue
+    rows.push({ name: parts[0], table_name: parts[1] })
+  }
+  return rows
+}
+
+function onFileChange(e: Event) {
+  csvError.value = null
+  csvPreview.value = []
+  importSuccess.value = null
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  const reader = new FileReader()
+  reader.onload = (ev) => {
+    const text = ev.target?.result as string
+    const rows = parseCSV(text)
+    if (!rows.length) { csvError.value = 'ไม่พบข้อมูลในไฟล์ — ตรวจสอบรูปแบบ name,table_name'; return }
+    csvPreview.value = rows
+  }
+  reader.readAsText(file, 'UTF-8')
+}
+
+async function importCSV() {
+  if (!csvPreview.value.length) return
+  importBusy.value = true
+  csvError.value = null
+  importSuccess.value = null
+  try {
+    const res = await apiFetch('/api/seats/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-mod-token': token.value },
+      body: JSON.stringify({ rows: csvPreview.value }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data.success) throw new Error(data.message || 'นำเข้าไม่สำเร็จ')
+    seats.value = data.seats
+    csvPreview.value = []
+    importSuccess.value = `นำเข้าสำเร็จ ${data.count} รายการ`
+  } catch (err: unknown) {
+    csvError.value = err instanceof Error ? err.message : 'นำเข้าไม่สำเร็จ'
+  } finally {
+    importBusy.value = false
+  }
+}
+
 async function load() {
   loading.value = true
   error.value = null
@@ -220,6 +279,46 @@ const filtered = () =>
               class="rounded-full bg-rose-600 px-5 py-2 text-sm text-white hover:bg-rose-700 disabled:opacity-50"
             >{{ addBusy ? 'กำลังบันทึก…' : 'เพิ่ม' }}</button>
           </form>
+        </div>
+
+        <!-- CSV Import -->
+        <div class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <h2 class="text-sm font-semibold text-gray-700 mb-1">นำเข้า CSV (เขียนทับทั้งหมด)</h2>
+          <p class="text-xs text-gray-400 mb-3">รูปแบบ: <code class="bg-gray-100 px-1 rounded">name,table_name</code> — หนึ่งแถวต่อหนึ่งแขก</p>
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            class="text-sm text-gray-600 file:mr-3 file:rounded-full file:border-0 file:bg-rose-50 file:px-4 file:py-1.5 file:text-sm file:text-rose-700 hover:file:bg-rose-100"
+            @change="onFileChange"
+          />
+          <p v-if="csvError" class="mt-2 text-xs text-rose-600">{{ csvError }}</p>
+          <p v-if="importSuccess" class="mt-2 text-xs text-green-600">{{ importSuccess }}</p>
+
+          <!-- Preview -->
+          <div v-if="csvPreview.length" class="mt-4">
+            <p class="text-xs text-gray-500 mb-2">พรีวิว {{ csvPreview.length }} รายการ (จะลบข้อมูลเดิมทั้งหมด)</p>
+            <div class="max-h-48 overflow-y-auto rounded-lg border border-gray-100 text-xs">
+              <table class="w-full">
+                <thead class="bg-gray-50 sticky top-0">
+                  <tr>
+                    <th class="px-3 py-2 text-left text-gray-500 font-medium">ชื่อ</th>
+                    <th class="px-3 py-2 text-left text-gray-500 font-medium">โต๊ะ</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(row, i) in csvPreview" :key="i" class="border-t border-gray-100">
+                    <td class="px-3 py-1.5 text-gray-700">{{ row.name }}</td>
+                    <td class="px-3 py-1.5 text-gray-700">{{ row.table_name }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <button
+              class="mt-3 rounded-full bg-rose-600 px-5 py-2 text-sm text-white hover:bg-rose-700 disabled:opacity-50"
+              :disabled="importBusy"
+              @click="importCSV"
+            >{{ importBusy ? 'กำลังนำเข้า…' : `นำเข้า ${csvPreview.length} รายการ` }}</button>
+          </div>
         </div>
 
         <!-- Header row -->

--- a/apps/frontend/src/views/TableView.vue
+++ b/apps/frontend/src/views/TableView.vue
@@ -39,7 +39,7 @@ async function search() {
 
 <template>
   <main class="min-h-screen bg-off-white text-gray-800">
-    <section class="mx-auto max-w-md px-4 py-12 sm:py-16">
+    <section class="mx-auto max-w-2xl px-4 py-12 sm:py-16">
       <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">ค้นหาโต๊ะของคุณ</h1>
       <p class="mt-3 text-gray-600">พิมพ์ชื่อเพื่อดูหมายเลขโต๊ะของคุณ</p>
 
@@ -49,7 +49,7 @@ async function search() {
           @input="onInput"
           @keydown.enter.prevent="search"
           type="text"
-          placeholder="ชื่อ-นามสกุล"
+          placeholder="ชื่อ"
           class="w-full rounded-lg border border-gray-300 px-4 py-3 text-lg shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
         />
       </div>
@@ -64,10 +64,10 @@ async function search() {
           :key="seat.id"
           class="flex items-center justify-between rounded-2xl border border-rose-100 bg-white px-5 py-4 shadow-sm"
         >
-          <p class="text-gray-800 font-medium">{{ seat.name }}</p>
+          <p class="text-gray-800 font-medium" style="font-family: 'Sarabun', sans-serif">{{ seat.name }}</p>
           <div class="text-right">
             <p class="text-xs text-gray-400 uppercase tracking-widest">โต๊ะ</p>
-            <p class="font-cookie text-3xl text-rose-600 leading-none">{{ seat.table_name }}</p>
+            <p class="text-2xl font-bold text-rose-600 leading-none" style="font-family: 'Sarabun', sans-serif">{{ seat.table_name }}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- `POST /api/seats/import` — overwrites all seats from CSV payload
- TableModerateView: file picker → parse CSV client-side → preview → confirm import
- Lottery / Table / Matchmaking input pages: `max-w-md` → `max-w-2xl` for better medium-screen use
- Nav: โต๊ะ → Table
- TableView: placeholder → ชื่อ, result card uses Sarabun font explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)