### PR TITLE
fix: extend digit spin to ~5s with stronger ease-out

### DIFF
--- a/apps/frontend/src/views/LotteryBoardView.vue
+++ b/apps/frontend/src/views/LotteryBoardView.vue
@@ -86,19 +86,21 @@ function spinSingleDigit(rank: number, pos: number, finalChar: string, onDone: (
   const digitCount = cfg(rank).digits
   const currentChars = (displayNumbers.value[rank] ?? '?'.repeat(digitCount)).split('')
   playDrawSound()
-  const TOTAL_TICKS = 20
+  // 30 ticks: delay ramps 20ms → 320ms = ~5s total, ease-out feel
+  const TOTAL_TICKS = 30
   let ticks = 0
   const tick = () => {
     currentChars[pos] = String(Math.floor(Math.random() * 10))
     displayNumbers.value[rank] = currentChars.join('')
     ticks++
     if (ticks < TOTAL_TICKS) {
-      setTimeout(tick, 40 + Math.floor((ticks / TOTAL_TICKS) * 140))
+      const delay = 20 + Math.floor((ticks / TOTAL_TICKS) * 300)
+      setTimeout(tick, delay)
     } else {
       currentChars[pos] = finalChar
       displayNumbers.value[rank] = currentChars.join('')
       revealedCount.value[rank] = pos + 1
-      setTimeout(onDone, 300)
+      setTimeout(onDone, 400)
     }
   }
   tick()


### PR DESCRIPTION
## Summary
- 20 ticks (40→180ms, ~2.2s) → 30 ticks (20→320ms, ~5s)
- Ramp starts fast then slows dramatically before locking — matches 3s sound effect duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)