### PR TITLE
feat: optional table number on lottery entries

### DIFF
--- a/apps/backend/src/db/migrations/0006_lottery_table_no.sql
+++ b/apps/backend/src/db/migrations/0006_lottery_table_no.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lottery_entries ADD COLUMN table_no TEXT;

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1747526400000,
       "tag": "0005_lottery_reveal",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1747612800000,
+      "tag": "0006_lottery_table_no",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -31,6 +31,7 @@ export const lotteryEntries = pgTable('lottery_entries', {
   id: serial('id').primaryKey(),
   name: text('name').notNull(),
   number: text('number').notNull().unique(),
+  tableNo: text('table_no'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 });
 

--- a/apps/backend/src/routes/lottery.ts
+++ b/apps/backend/src/routes/lottery.ts
@@ -21,14 +21,15 @@ export const lotteryRoutes = new Elysia()
       set.status = 400;
       return { success: false, message: 'หมายเลขต้องมี 6 หลักเท่านั้น' };
     }
+    const tableNo = body.table_no?.trim() || null;
     try {
       const result = await Effect.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
-          const rows = yield* sql<{ id: number; name: string; number: string; created_at: string }>`
-            insert into lottery_entries (name, number)
-            values (${body.name.trim()}, ${num})
-            returning id, name, number, created_at
+          const rows = yield* sql<{ id: number; name: string; number: string; table_no: string | null; created_at: string }>`
+            insert into lottery_entries (name, number, table_no)
+            values (${body.name.trim()}, ${num}, ${tableNo})
+            returning id, name, number, table_no, created_at
           `;
           return rows[0];
         }).pipe(Effect.provide(LiveDatabase))
@@ -46,6 +47,7 @@ export const lotteryRoutes = new Elysia()
     body: t.Object({
       name: t.String({ minLength: 1, maxLength: 120 }),
       number: t.String({ minLength: 1, maxLength: 6 }),
+      table_no: t.Optional(t.String({ maxLength: 20 })),
     }),
   })
   .get('/api/lottery/numbers', async ({ headers, set }) => {
@@ -71,8 +73,8 @@ export const lotteryRoutes = new Elysia()
       const rows = await Effect.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
-          return yield* sql<{ id: number; name: string; number: string; created_at: string }>`
-            select id, name, number, created_at from lottery_entries order by created_at asc
+          return yield* sql<{ id: number; name: string; number: string; table_no: string | null; created_at: string }>`
+            select id, name, number, table_no, created_at from lottery_entries order by created_at asc
           `;
         }).pipe(Effect.provide(LiveDatabase))
       );
@@ -198,8 +200,8 @@ export const lotteryRoutes = new Elysia()
           const draws = yield* sql<{ id: number; prize_rank: number; winning_number: string; revealed_digits: number; drawn_at: string }>`
             select id, prize_rank, winning_number, revealed_digits, drawn_at from lottery_draws order by prize_rank asc
           `;
-          const entries = yield* sql<{ name: string; number: string; created_at: string }>`
-            select name, number, created_at from lottery_entries order by created_at asc
+          const entries = yield* sql<{ name: string; number: string; table_no: string | null; created_at: string }>`
+            select name, number, table_no, created_at from lottery_entries order by created_at asc
           `;
           return { draws, entries };
         }).pipe(Effect.provide(LiveDatabase))

--- a/apps/frontend/src/views/LotteryBoardView.vue
+++ b/apps/frontend/src/views/LotteryBoardView.vue
@@ -9,13 +9,14 @@ type DrawResult = {
   winning_number: string
   revealed_digits: number
   drawn_at: string
-  winners: { name: string; number: string }[]
+  winners: { name: string; number: string; table_no: string | null }[]
 }
 
 type Bubble = {
   id: number
   name: string
   number: string
+  table_no: string | null
   x: number  // vw %
   y: number  // vh %
   visible: boolean
@@ -38,14 +39,14 @@ const seenNumbers = ref(new Set<string>())
 const initialLoad = ref(true)
 let bubbleIdSeq = 0
 
-function spawnBubble(name: string, number: string) {
+function spawnBubble(name: string, number: string, table_no: string | null) {
   const id = ++bubbleIdSeq
   // Keep away from center column (prize cards): left 5–30% or right 65–90%
   const side = Math.random() < 0.5
   const x = side ? 5 + Math.random() * 25 : 65 + Math.random() * 25
   const y = 10 + Math.random() * 75
 
-  bubbles.value.push({ id, name, number, x, y, visible: false })
+  bubbles.value.push({ id, name, number, table_no, x, y, visible: false })
 
   // Tick to let Vue render the element, then fade in
   nextTick(() => {
@@ -134,12 +135,12 @@ async function pollResults() {
     if (typeof data.total_entries === 'number') totalEntries.value = data.total_entries
 
     // Bubble: detect new entries (skip on very first load to avoid flood)
-    const recentEntries = (data.recent_entries ?? []) as { name: string; number: string }[]
+    const recentEntries = (data.recent_entries ?? []) as { name: string; number: string; table_no: string | null }[]
     if (!initialLoad.value) {
       for (const e of recentEntries) {
         if (!seenNumbers.value.has(e.number)) {
           seenNumbers.value.add(e.number)
-          spawnBubble(e.name, e.number)
+          spawnBubble(e.name, e.number, e.table_no ?? null)
         }
       }
     } else {
@@ -222,6 +223,7 @@ function getResult(rank: number): DrawResult | undefined {
         }"
       >
         <span class="bubble-name">{{ bubble.name }}</span>
+        <span v-if="bubble.table_no" class="bubble-table">โต๊ะ {{ bubble.table_no }}</span>
         <span class="bubble-number">{{ bubble.number }}</span>
       </div>
     </Teleport>
@@ -283,7 +285,8 @@ function getResult(rank: number): DrawResult | undefined {
               class="text-lg sm:text-2xl font-semibold text-white"
             >
               🎉 {{ w.name }}
-              <span class="font-mono text-sm font-normal opacity-50">{{ w.number }}</span>
+              <span v-if="w.table_no" class="ml-1 text-base font-normal text-rose-300">โต๊ะ {{ w.table_no }}</span>
+              <span class="font-mono text-sm font-normal opacity-40 ml-1">{{ w.number }}</span>
             </p>
           </div>
           <p v-else class="text-gray-600 text-sm">ไม่มีผู้ถูกรางวัล</p>
@@ -318,10 +321,16 @@ function getResult(rank: number): DrawResult | undefined {
   color: #fff;
 }
 
+.bubble-table {
+  font-size: 0.8rem;
+  color: #fda4af;
+  opacity: 0.9;
+}
+
 .bubble-number {
   font-family: ui-monospace, monospace;
   font-size: 0.8rem;
   color: #fb7185;
-  opacity: 0.85;
+  opacity: 0.7;
 }
 </style>

--- a/apps/frontend/src/views/LotteryModerateView.vue
+++ b/apps/frontend/src/views/LotteryModerateView.vue
@@ -2,14 +2,14 @@
 import { ref, computed } from 'vue'
 import { apiFetch } from '@/lib/api'
 
-type Entry = { id: number; name: string; number: string; created_at: string }
+type Entry = { id: number; name: string; number: string; table_no: string | null; created_at: string }
 type DrawResult = {
   id: number
   prize_rank: number
   winning_number: string
   revealed_digits: number
   drawn_at: string
-  winners: { name: string; number: string }[]
+  winners: { name: string; number: string; table_no: string | null }[]
 }
 
 type Rank = 1 | 2 | 3
@@ -305,6 +305,7 @@ const winnerNumbers = computed(() => {
             >
               <span class="font-mono font-bold">{{ entry.number }}</span>
               <span class="ml-2 text-gray-500">{{ entry.name }}</span>
+              <span v-if="entry.table_no" class="ml-1 text-xs text-gray-400">โต๊ะ {{ entry.table_no }}</span>
             </div>
             <p v-if="entries.length === 0" class="text-gray-400 text-sm">ยังไม่มีผู้เข้าร่วม</p>
           </div>

--- a/apps/frontend/src/views/LotteryView.vue
+++ b/apps/frontend/src/views/LotteryView.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { apiFetch } from '@/lib/api'
 
 const name = ref('')
+const tableNo = ref('')
 const number = ref('')
 const loading = ref(false)
 const success = ref<string | null>(null)
@@ -35,12 +36,13 @@ async function submit() {
     const res = await apiFetch('/api/lottery', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name.value.trim(), number: number.value.trim() }),
+      body: JSON.stringify({ name: name.value.trim(), number: number.value.trim(), table_no: tableNo.value.trim() || undefined }),
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok || !data?.success) throw new Error(data?.message || 'ส่งข้อมูลไม่สำเร็จ กรุณาลองใหม่อีกครั้ง')
     success.value = `${name.value.trim()} เข้าร่วมลุ้นโชคแล้ว! ขอให้โชคดี! 🍀`
     name.value = ''
+    tableNo.value = ''
     number.value = ''
   } catch (err: unknown) {
     error.value = err instanceof Error ? err.message : 'เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง'
@@ -76,6 +78,20 @@ async function submit() {
             required
             type="text"
             placeholder="ชื่อที่จะแสดงบนจอ"
+            class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          />
+        </div>
+
+        <div>
+          <label for="tableNo" class="block text-sm font-medium text-gray-700">
+            หมายเลขโต๊ะ <span class="text-gray-400 font-normal">(ไม่บังคับ)</span>
+          </label>
+          <input
+            id="tableNo"
+            v-model="tableNo"
+            type="text"
+            maxlength="20"
+            placeholder="เช่น 5, A3"
             class="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2.5 shadow-sm placeholder:text-gray-400 focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
           />
         </div>


### PR DESCRIPTION
## Summary
- New optional "หมายเลขโต๊ะ" field on `/lottery` registration form
- Winner line on board: `🎉 สมชาย  โต๊ะ 5  123456` — announcer can call table
- Entry bubbles show table number when present
- Mod entry list shows table number per entry
- `table_no TEXT` column (nullable) added; migration 0006 already applied to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)