### PR TITLE
fix: shared DB connection pool — fixes connection timeout under load

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -1,17 +1,24 @@
-import { Config } from "effect";
+import { Config, ManagedRuntime } from "effect";
 import { PgClient } from "@effect/sql-pg";
 
-// 1. Define the Config structure for the PgClient options
+// Config for the PgClient / connection pool
 const PgClientConfig = Config.all({
   host: Config.string("DATABASE_HOST"),
   port: Config.number("DATABASE_PORT").pipe(Config.withDefault(5432)),
   username: Config.string("DATABASE_USER"),
-  password: Config.redacted("DATABASE_PASSWORD"), // Keep password redacted as required by PgClientConfig
+  password: Config.redacted("DATABASE_PASSWORD"),
   database: Config.string("DATABASE_NAME"),
-  // Enable SSL/TLS if required by the provider (e.g., Render). Defaults to true.
   ssl: Config.boolean("DATABASE_SSL").pipe(Config.withDefault(true)),
+  // Pool tuning — prevents stale-connection timeouts under load
+  maxConnections: Config.succeed(5),           // keep total connections low (Render limit)
+  idleTimeoutMillis: Config.succeed(30_000),   // close idle connections after 30s (Render kills at 300s)
+  connectionTimeoutMillis: Config.succeed(10_000), // fail fast if pool exhausted
+  keepAlive: Config.succeed(true),             // TCP keepalive — detect dead connections early
 });
 
-// 2. Create the Live Layer for the Effect application using PgClient.layerConfig
-// PgClient.layerConfig connects the configured client and also provides the generic SqlClient
+// Layer — describes how to build the PgClient
 export const LiveDatabase = PgClient.layerConfig(PgClientConfig);
+
+// Shared runtime — built ONCE at startup, reused for every request.
+// Eliminates the "new connection per Effect.runPromise" bug.
+export const dbRuntime = ManagedRuntime.make(LiveDatabase);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -3,7 +3,7 @@ import { Elysia } from 'elysia';
 import { cors } from '@elysiajs/cors';
 import { Effect } from 'effect';
 import { SqlClient } from '@effect/sql';
-import { LiveDatabase } from './db';
+import { dbRuntime } from './db';
 import { rsvpRoutes } from './routes/rsvp';
 import { matchmakingRoutes } from './routes/matchmaking';
 import { lotteryRoutes } from './routes/lottery';
@@ -14,7 +14,7 @@ const dbHealthCheck = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
   const rows = yield* sql<{ ok: number }>`select 1 as ok`;
   return rows?.[0]?.ok === 1;
-}).pipe(Effect.provide(LiveDatabase));
+});
 
 const app = new Elysia()
   .use(cors({
@@ -24,7 +24,7 @@ const app = new Elysia()
   .get('/api/greeting', () => ({ message: 'Welcome to our wedding website API!' }))
   .get('/api/health/db', async () => {
     try {
-      const ok = await Effect.runPromise(dbHealthCheck);
+      const ok = await dbRuntime.runPromise(dbHealthCheck);
       return ok
         ? { status: 'ok', message: 'Database connection successful' }
         : { status: 'degraded', message: 'Database check did not return expected result' };
@@ -40,7 +40,7 @@ const app = new Elysia()
   .use(seatsRoutes)
   .listen(3000);
 
-Effect.runPromise(dbHealthCheck)
+dbRuntime.runPromise(dbHealthCheck)
   .then((ok) => {
     if (ok) console.log('✅ Database connection successful');
     else console.warn('⚠️ Database connection check returned unexpected result');

--- a/apps/backend/src/routes/hunt.ts
+++ b/apps/backend/src/routes/hunt.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { Effect } from 'effect';
 import { SqlClient } from '@effect/sql';
-import { LiveDatabase } from '../db';
+import { dbRuntime } from '../db';
 import { requireServiceKey, requireModToken } from '../lib/auth';
 
 // Mission Hunt routes — see llm-wiki/requirements/mission-hunt.md.
@@ -44,7 +44,7 @@ export const huntRoutes = new Elysia()
     const authErr = requireServiceKey(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<Omit<MissionRow, 'description'> & { description: string | null }>`
@@ -53,7 +53,7 @@ export const huntRoutes = new Elysia()
             where active = true
             order by position asc, id asc
           `;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return { success: true, missions: rows };
     } catch (error) {
@@ -80,7 +80,7 @@ export const huntRoutes = new Elysia()
     }
 
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
 
@@ -118,7 +118,7 @@ export const huntRoutes = new Elysia()
             createdAt: inserted[0]!.created_at,
             pointsAwarded: alreadyEarned ? 0 : missionPoints,
           };
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
 
       if (result.kind === 'mission_missing') {
@@ -151,7 +151,7 @@ export const huntRoutes = new Elysia()
     const since = typeof query.since === 'string' ? new Date(query.since) : null;
     const sinceValid = since && !Number.isNaN(since.getTime());
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           // Photos are visible to the mosaic only after FEED_DELAY_MS elapsed,
@@ -178,7 +178,7 @@ export const huntRoutes = new Elysia()
             order by created_at desc
             limit ${limit}
           `;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return {
         success: true,
@@ -205,7 +205,7 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'Invalid id' };
     }
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{ id: number; mission_id: number; hunter_name: string; full_base64: string; approved: boolean; created_at: string }>`
@@ -213,7 +213,7 @@ export const huntRoutes = new Elysia()
             from hunt_photos
             where id = ${id} and approved = true
           `;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       const row = rows[0];
       if (!row) {
@@ -240,7 +240,7 @@ export const huntRoutes = new Elysia()
     if (authErr) return authErr;
     const limit = Math.min(Math.max(Number(query.limit ?? 20) || 20, 1), 100);
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           // Score = sum of points across distinct missions the hunter completed
@@ -277,7 +277,7 @@ export const huntRoutes = new Elysia()
             order by sum(m.points) desc, count(*) desc, hln.hunter_name asc
             limit ${limit}
           `;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return {
         success: true,
@@ -303,7 +303,7 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'token query param required.' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const completed = yield* sql<{ mission_id: number; points: number }>`
@@ -313,7 +313,7 @@ export const huntRoutes = new Elysia()
             where p.hunter_token = ${token} and p.approved = true
           `;
           return completed;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       const completedMissionIds = result.map((r) => r.mission_id);
       const totalPoints = result.reduce((sum, r) => sum + Number(r.points), 0);
@@ -331,7 +331,7 @@ export const huntRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<Omit<PhotoRow, 'full_base64'>>`
@@ -341,7 +341,7 @@ export const huntRoutes = new Elysia()
             order by created_at desc
             limit 500
           `;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return {
         success: true,
@@ -370,7 +370,7 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'Invalid id' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{ id: number; approved: boolean }>`
@@ -378,7 +378,7 @@ export const huntRoutes = new Elysia()
             returning id, approved
           `;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       if (!result) {
         set.status = 404;
@@ -401,12 +401,12 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'Invalid id' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{ id: number }>`delete from hunt_photos where id = ${id} returning id`;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       if (!result) {
         set.status = 404;
@@ -422,7 +422,7 @@ export const huntRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      const deleted = await Effect.runPromise(
+      const deleted = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{ count: string }>`
@@ -430,7 +430,7 @@ export const huntRoutes = new Elysia()
             select count(*)::text as count from d
           `;
           return Number(rows[0]?.count ?? 0);
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return { success: true, deletedPhotoCount: deleted };
     } catch (error) {
@@ -446,7 +446,7 @@ export const huntRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<MissionRow>`
@@ -454,7 +454,7 @@ export const huntRoutes = new Elysia()
             from hunt_missions
             order by position asc, id asc
           `;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return { success: true, missions: rows };
     } catch (error) {
@@ -470,7 +470,7 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'Example thumbnail too large.' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           // If position is omitted, append at the end.
@@ -488,7 +488,7 @@ export const huntRoutes = new Elysia()
             returning id, position, title, description, example_thumb_base64, points, active, created_at
           `;
           return rows[0]!;
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return { success: true, mission: result };
     } catch (error) {
@@ -518,7 +518,7 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'Example thumbnail too large.' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<MissionRow>`
@@ -533,7 +533,7 @@ export const huntRoutes = new Elysia()
             returning id, position, title, description, example_thumb_base64, points, active, created_at
           `;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       if (!result) {
         set.status = 404;
@@ -563,7 +563,7 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'Invalid id' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const photoCount = yield* sql<{ count: string }>`
@@ -571,7 +571,7 @@ export const huntRoutes = new Elysia()
           `;
           const rows = yield* sql<{ id: number }>`delete from hunt_missions where id = ${id} returning id`;
           return { row: rows[0], deletedPhotoCount: Number(photoCount[0]?.count ?? 0) };
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       if (!result.row) {
         set.status = 404;
@@ -595,7 +595,7 @@ export const huntRoutes = new Elysia()
       return { success: false, message: 'orderedIds must be a non-empty array.' };
     }
     try {
-      await Effect.runPromise(
+      await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           // Two-step rewrite to avoid hypothetical unique-constraint conflicts:
@@ -606,7 +606,7 @@ export const huntRoutes = new Elysia()
             const newPos = i + 1;
             yield* sql`update hunt_missions set position = ${newPos} where id = ${id}`;
           }
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return { success: true, count: body.orderedIds.length };
     } catch (error) {
@@ -624,7 +624,7 @@ export const huntRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      const counts = await Effect.runPromise(
+      const counts = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const photos = yield* sql<{ count: string }>`
@@ -639,7 +639,7 @@ export const huntRoutes = new Elysia()
             deletedPhotoCount: Number(photos[0]?.count ?? 0),
             deletedMissionCount: Number(missions[0]?.count ?? 0),
           };
-        }).pipe(Effect.provide(LiveDatabase)),
+        }),
       );
       return { success: true, ...counts };
     } catch (error) {

--- a/apps/backend/src/routes/lottery.ts
+++ b/apps/backend/src/routes/lottery.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { Effect } from 'effect';
 import { SqlClient } from '@effect/sql';
-import { LiveDatabase } from '../db';
+import { dbRuntime } from '../db';
 import { requireServiceKey, requireModToken } from '../lib/auth';
 import { isUniqueViolation } from '../lib/errors';
 
@@ -23,7 +23,7 @@ export const lotteryRoutes = new Elysia()
     }
     const tableNo = body.table_no?.trim() || null;
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{ id: number; name: string; number: string; table_no: string | null; created_at: string }>`
@@ -32,7 +32,7 @@ export const lotteryRoutes = new Elysia()
             returning id, name, number, table_no, created_at
           `;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, entry: result };
     } catch (error: unknown) {
@@ -54,11 +54,11 @@ export const lotteryRoutes = new Elysia()
     const authErr = requireServiceKey(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{ number: string }>`select number from lottery_entries`;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, numbers: rows.map(r => r.number) };
     } catch (error) {
@@ -70,13 +70,13 @@ export const lotteryRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{ id: number; name: string; number: string; table_no: string | null; created_at: string }>`
             select id, name, number, table_no, created_at from lottery_entries order by created_at asc
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, entries: rows };
     } catch (error) {
@@ -93,13 +93,13 @@ export const lotteryRoutes = new Elysia()
       return { success: false, message: 'ลำดับรางวัลต้องเป็น 1, 2 หรือ 3 เท่านั้น' };
     }
     try {
-      const { entries, draws } = await Effect.runPromise(
+      const { entries, draws } = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const entries = yield* sql<{ name: string; number: string }>`select name, number from lottery_entries`;
           const draws = yield* sql<{ prize_rank: number; winning_number: string }>`select prize_rank, winning_number from lottery_draws`;
           return { entries, draws };
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
 
       if (entries.length === 0) {
@@ -138,14 +138,14 @@ export const lotteryRoutes = new Elysia()
       const pool = [...new Set(eligibleEntries.map(e => extract(e.number, body.prizeRank)))];
       const winningNumber = pool[Math.floor(Math.random() * pool.length)];
 
-      await Effect.runPromise(
+      await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           yield* sql`
             insert into lottery_draws (prize_rank, winning_number, revealed_digits)
             values (${body.prizeRank}, ${winningNumber}, 0)
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, winningNumber };
     } catch (error: unknown) {
@@ -168,7 +168,7 @@ export const lotteryRoutes = new Elysia()
       return { success: false, message: 'invalid draw id' };
     }
     try {
-      const updated = await Effect.runPromise(
+      const updated = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{ id: number; prize_rank: number; revealed_digits: number }>`
@@ -178,7 +178,7 @@ export const lotteryRoutes = new Elysia()
             returning id, prize_rank, revealed_digits
           `;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       if (!updated) {
         set.status = 404;
@@ -194,7 +194,7 @@ export const lotteryRoutes = new Elysia()
     const authErr = requireServiceKey(headers, set);
     if (authErr) return authErr;
     try {
-      const { draws, entries } = await Effect.runPromise(
+      const { draws, entries } = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const draws = yield* sql<{ id: number; prize_rank: number; winning_number: string; revealed_digits: number; drawn_at: string }>`
@@ -204,7 +204,7 @@ export const lotteryRoutes = new Elysia()
             select name, number, table_no, created_at from lottery_entries order by created_at asc
           `;
           return { draws, entries };
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
 
       const results = draws.map((draw) => ({
@@ -223,11 +223,11 @@ export const lotteryRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      await Effect.runPromise(
+      await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           yield* sql`delete from lottery_draws`;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true };
     } catch (error) {
@@ -239,12 +239,12 @@ export const lotteryRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      await Effect.runPromise(
+      await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           yield* sql`delete from lottery_draws`;
           yield* sql`delete from lottery_entries`;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true };
     } catch (error) {

--- a/apps/backend/src/routes/matchmaking.ts
+++ b/apps/backend/src/routes/matchmaking.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { Effect } from 'effect';
 import { SqlClient } from '@effect/sql';
-import { LiveDatabase } from '../db';
+import { dbRuntime } from '../db';
 import { requireServiceKey, requireModToken } from '../lib/auth';
 
 export const matchmakingRoutes = new Elysia()
@@ -13,7 +13,7 @@ export const matchmakingRoutes = new Elysia()
       return { success: false, message: 'รูปภาพมีขนาดใหญ่เกินไป กรุณาเลือกรูปที่เล็กกว่า' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{
@@ -25,7 +25,7 @@ export const matchmakingRoutes = new Elysia()
             returning id, submitter_name, friend_name, contact, bio, photo_base64, approved, created_at
           `;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, submission: result };
     } catch (error) {
@@ -45,7 +45,7 @@ export const matchmakingRoutes = new Elysia()
     const authErr = requireServiceKey(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{
@@ -57,7 +57,7 @@ export const matchmakingRoutes = new Elysia()
             where approved = true
             order by created_at desc
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, submissions: rows };
     } catch (error) {
@@ -69,7 +69,7 @@ export const matchmakingRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{
@@ -80,7 +80,7 @@ export const matchmakingRoutes = new Elysia()
             from matchmaking_submissions
             order by created_at desc
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, submissions: rows };
     } catch (error) {
@@ -97,7 +97,7 @@ export const matchmakingRoutes = new Elysia()
       return { success: false, message: 'ID ไม่ถูกต้อง' };
     }
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{ id: number; approved: boolean }>`
@@ -107,7 +107,7 @@ export const matchmakingRoutes = new Elysia()
             returning id, approved
           `;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       if (!result) {
         set.status = 404;
@@ -125,11 +125,11 @@ export const matchmakingRoutes = new Elysia()
     const authErr = requireModToken(headers, set);
     if (authErr) return authErr;
     try {
-      await Effect.runPromise(
+      await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           yield* sql`delete from matchmaking_submissions`;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true };
     } catch (error) {

--- a/apps/backend/src/routes/rsvp.ts
+++ b/apps/backend/src/routes/rsvp.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { Effect } from 'effect';
 import { SqlClient } from '@effect/sql';
-import { LiveDatabase } from '../db';
+import { dbRuntime } from '../db';
 import { requireServiceKey } from '../lib/auth';
 
 export const rsvpRoutes = new Elysia()
@@ -9,7 +9,7 @@ export const rsvpRoutes = new Elysia()
     const authErr = requireServiceKey(headers, set);
     if (authErr) return authErr;
     try {
-      const result = await Effect.runPromise(
+      const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{
@@ -20,7 +20,7 @@ export const rsvpRoutes = new Elysia()
             returning id, name, attending, guests, message, created_at
           `;
           return rows[0];
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, rsvp: result };
     } catch (error) {
@@ -39,13 +39,13 @@ export const rsvpRoutes = new Elysia()
     const authErr = requireServiceKey(headers, set);
     if (authErr) return authErr;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{
             id: number; name: string; attending: boolean; guests: number; message: string | null; created_at: string;
           }>`select id, name, attending, guests, message, created_at from rsvps order by created_at desc`;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, rsvps: rows };
     } catch (error) {

--- a/apps/backend/src/routes/seats.ts
+++ b/apps/backend/src/routes/seats.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { Effect } from 'effect';
 import { SqlClient } from '@effect/sql';
-import { LiveDatabase } from '../db';
+import { dbRuntime } from '../db';
 import { requireModToken } from '../lib/auth';
 
 export const seatsRoutes = new Elysia()
@@ -11,7 +11,7 @@ export const seatsRoutes = new Elysia()
     const q = (query.q ?? '').trim();
     if (!q) return { success: true, seats: [] };
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{ id: number; name: string; table_name: string }>`
@@ -21,7 +21,7 @@ export const seatsRoutes = new Elysia()
             ORDER BY name ASC
             LIMIT 20
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, seats: rows };
     } catch {
@@ -35,13 +35,13 @@ export const seatsRoutes = new Elysia()
     const auth = requireModToken(headers, set);
     if (auth) return auth;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{ id: number; name: string; table_name: string }>`
             SELECT id, name, table_name FROM seats ORDER BY table_name ASC, name ASC
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, seats: rows };
     } catch {
@@ -55,14 +55,14 @@ export const seatsRoutes = new Elysia()
     const auth = requireModToken(headers, set);
     if (auth) return auth;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{ id: number; name: string; table_name: string }>`
             INSERT INTO seats (name, table_name) VALUES (${body.name.trim()}, ${body.table_name.trim()})
             RETURNING id, name, table_name
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, seat: rows[0] };
     } catch {
@@ -81,7 +81,7 @@ export const seatsRoutes = new Elysia()
     const auth = requireModToken(headers, set);
     if (auth) return auth;
     try {
-      const rows = await Effect.runPromise(
+      const rows = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           return yield* sql<{ id: number; name: string; table_name: string }>`
@@ -89,7 +89,7 @@ export const seatsRoutes = new Elysia()
             WHERE id = ${Number(params.id)}
             RETURNING id, name, table_name
           `;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       if (!rows.length) { set.status = 404; return { success: false, message: 'ไม่พบข้อมูล' }; }
       return { success: true, seat: rows[0] };
@@ -109,11 +109,11 @@ export const seatsRoutes = new Elysia()
     const auth = requireModToken(headers, set);
     if (auth) return auth;
     try {
-      await Effect.runPromise(
+      await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           yield* sql`DELETE FROM seats WHERE id = ${Number(params.id)}`;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true };
     } catch {
@@ -129,7 +129,7 @@ export const seatsRoutes = new Elysia()
     const rows = body.rows;
     if (!rows.length) { set.status = 400; return { success: false, message: 'ไม่มีข้อมูลที่จะนำเข้า' }; }
     try {
-      const inserted = await Effect.runPromise(
+      const inserted = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           yield* sql`DELETE FROM seats`;
@@ -142,7 +142,7 @@ export const seatsRoutes = new Elysia()
             if (r[0]) results.push(r[0]);
           }
           return results;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true, count: inserted.length, seats: inserted };
     } catch (err) {
@@ -164,11 +164,11 @@ export const seatsRoutes = new Elysia()
     const auth = requireModToken(headers, set);
     if (auth) return auth;
     try {
-      await Effect.runPromise(
+      await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           yield* sql`DELETE FROM seats`;
-        }).pipe(Effect.provide(LiveDatabase))
+        })
       );
       return { success: true };
     } catch {

--- a/apps/frontend/src/views/LotteryBoardView.vue
+++ b/apps/frontend/src/views/LotteryBoardView.vue
@@ -228,7 +228,7 @@ function getResult(rank: number): DrawResult | undefined {
       </div>
     </Teleport>
 
-    <h1 class="font-cookie text-5xl sm:text-7xl text-rose-400 mb-2 tracking-wide">สลากกินไม่แบ่ง กินอยู่คนเดียว</h1>
+    <h1 class="font-cookie text-5xl sm:text-4xl text-rose-400 mb-2 tracking-wide">สลากกินไม่แบ่ง กินอยู่คนเดียว</h1>
     <p class="text-gray-500 text-xs tracking-widest uppercase">งานแต่งงานส้ม &amp; ปัณณ์</p>
 
     <!-- Participant count -->

--- a/apps/frontend/src/views/LotteryView.vue
+++ b/apps/frontend/src/views/LotteryView.vue
@@ -55,7 +55,7 @@ async function submit() {
 <template>
   <main class="min-h-screen bg-off-white text-gray-800">
     <section class="mx-auto max-w-2xl px-4 py-12 sm:py-16">
-      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">สลากกินไม่แบ่ง กินอยู่คนเดียว</h1>
+      <h1 class="font-cookie text-5xl sm:text-4xl text-rose-600">สลากกินไม่แบ่ง กินอยู่คนเดียว</h1>
       <p class="mt-3 text-gray-600">เลือกหมายเลข 6 หลักนำโชคของคุณ และร่วมลุ้นรับรางวัลในงาน!</p>
       <div class="mt-1 space-y-1">
         <p class="text-sm text-rose-500 font-medium">หมายเลขต้องไม่ซ้ำกับคนอื่น ตรวจสอบหมายเลขที่ถูกใช้แล้วด้านล่าง</p>

--- a/apps/frontend/src/views/MatchmakingBoardView.vue
+++ b/apps/frontend/src/views/MatchmakingBoardView.vue
@@ -49,7 +49,7 @@ const marqueeStyle = computed(() => {
   <main class="min-h-screen bg-gradient-to-br from-rose-50 via-white to-rose-100 overflow-hidden px-0 py-8">
     <header class="mb-8 text-center px-6">
       <p class="text-sm uppercase tracking-[0.3em] text-rose-600">Kaywalee &amp; Supanat · Wedding Activity</p>
-      <h1 class="font-cookie mt-2 text-6xl sm:text-7xl text-rose-600">มุมคนโสดโดยความสามารถ</h1>
+      <h1 class="font-cookie mt-2 text-5xl text-rose-600">มุมคนโสดโดยความสามารถ</h1>
       <p class="mt-2 text-gray-600">มาทำความรู้จักเพื่อนโสดสุดน่ารักของเรากันเถอะ!</p>
     </header>
 

--- a/apps/frontend/src/views/MatchmakingBoardView.vue
+++ b/apps/frontend/src/views/MatchmakingBoardView.vue
@@ -49,7 +49,7 @@ const marqueeStyle = computed(() => {
   <main class="min-h-screen bg-gradient-to-br from-rose-50 via-white to-rose-100 overflow-hidden px-0 py-8">
     <header class="mb-8 text-center px-6">
       <p class="text-sm uppercase tracking-[0.3em] text-rose-600">Kaywalee &amp; Supanat · Wedding Activity</p>
-      <h1 class="font-cookie mt-2 text-5xl text-rose-600">มุมคนโสดโดยความสามารถ</h1>
+      <h1 class="font-cookie mt-6 text-5xl text-rose-600">มุมคนโสดโดยความสามารถ</h1>
       <p class="mt-2 text-gray-600">มาทำความรู้จักเพื่อนโสดสุดน่ารักของเรากันเถอะ!</p>
     </header>
 

--- a/apps/frontend/src/views/MatchmakingView.vue
+++ b/apps/frontend/src/views/MatchmakingView.vue
@@ -110,7 +110,7 @@ async function submit() {
 <template>
   <main class="min-h-screen bg-off-white text-gray-800">
     <section class="mx-auto max-w-2xl px-4 py-12 sm:py-16">
-      <h1 class="font-cookie text-5xl sm:text-6xl text-rose-600">มุมคนโสดโดยความสามารถ</h1>
+      <h1 class="font-cookie text-5xl text-rose-600">มุมคนโสดโดยความสามารถ</h1>
       <p class="mt-3 text-gray-600">
         รู้จักเพื่อนโสดดี ๆ ไหม? บอกเราเรื่องราวของพวกเขา!
         เราจะแสดงรายชื่อบนจอใหญ่ที่งานแต่งงาน เผื่อใครสนใจทักทาย


### PR DESCRIPTION
## Problem
`SqlError: PgClient: Connection timed out` under concurrent load (7+ devices polling every 3s).

**Root cause:** Every `Effect.runPromise(effect.pipe(Effect.provide(LiveDatabase)))` built a fresh `PgClient` layer = fresh connection. Connections piled up and exhausted Render's limit.

## Fix
- Export `dbRuntime = ManagedRuntime.make(LiveDatabase)` — built once at startup
- All routes use `dbRuntime.runPromise(effect)` — single shared pool for server lifetime
- Pool config: `maxConnections=5`, `idleTimeoutMillis=30s`, `connectionTimeoutMillis=10s`, `keepAlive=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)