### PR TITLE
Fix lottery draw sound, remove RSVP, git rules doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ bun run index.ts
 ```
 
 This project was created using `bun init` in bun v1.2.23. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+
+---
+
+## Git / PR Rules
+
+- **Never merge to `main` without explicit user instruction.**
+- **Never delete any branch without explicit user instruction.**
+- When creating PR, always pass `--delete-branch=false` to `gh pr merge`.
+- GitHub repo may have "Automatically delete head branches" enabled — disable it in Settings → General to prevent silent branch deletion after merge.
+- If `develop` loses upstream tracking after a merge, restore with:
+  ```bash
+  git branch --set-upstream-to=origin/develop develop
+  ```

--- a/apps/frontend/src/views/LotteryBoardView.vue
+++ b/apps/frontend/src/views/LotteryBoardView.vue
@@ -3,6 +3,21 @@ import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import { apiFetch } from '@/lib/api'
 import drawSoundUrl from '@/assets/sound-effect/lottery-drawing-effect.mp3'
 
+// Pre-load audio once and keep reference; browser autoplay unlock on first user gesture
+let drawAudio: HTMLAudioElement | null = null
+let audioUnlocked = false
+
+function unlockAudio() {
+  if (audioUnlocked) return
+  audioUnlocked = true
+  // Pre-load the file so it's ready to play instantly
+  drawAudio = new Audio(drawSoundUrl)
+  drawAudio.load()
+  window.removeEventListener('click', unlockAudio)
+  window.removeEventListener('touchstart', unlockAudio)
+  window.removeEventListener('keydown', unlockAudio)
+}
+
 type DrawResult = {
   id: number
   prize_rank: number
@@ -78,8 +93,12 @@ const animating = ref<Record<number, boolean>>({ 1: false, 2: false, 3: false })
 
 function playDrawSound() {
   try {
-    const audio = new Audio(drawSoundUrl)
-    audio.play().catch(() => {})
+    if (!drawAudio) {
+      drawAudio = new Audio(drawSoundUrl)
+      drawAudio.load()
+    }
+    drawAudio.currentTime = 0
+    drawAudio.play().catch(() => {})
   } catch { /* silent */ }
 }
 
@@ -195,11 +214,19 @@ async function pollResults() {
 let interval: ReturnType<typeof setInterval>
 
 onMounted(() => {
+  window.addEventListener('click', unlockAudio)
+  window.addEventListener('touchstart', unlockAudio)
+  window.addEventListener('keydown', unlockAudio)
   pollResults()
   interval = setInterval(pollResults, 3000)
 })
 
-onUnmounted(() => clearInterval(interval))
+onUnmounted(() => {
+  clearInterval(interval)
+  window.removeEventListener('click', unlockAudio)
+  window.removeEventListener('touchstart', unlockAudio)
+  window.removeEventListener('keydown', unlockAudio)
+})
 
 function getResult(rank: number): DrawResult | undefined {
   return results.value.find((r) => r.prize_rank === rank)


### PR DESCRIPTION
## Summary
- Fix lottery draw sound not playing (browser autoplay policy — unlock on first user gesture)
- Remove RSVP from nav, disable RSVP button on home page
- Change table finder icon to magnifying glass
- Add git/PR rules to README (no delete branch, no merge without permission)

## Test plan
- [ ] Open lottery board, tap anywhere, trigger draw reveal → sound plays
- [ ] Nav: no RSVP link on desktop/mobile
- [ ] Home: RSVP button grayed out, non-clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)