### PR TITLE
feat: prevent duplicate lottery entries via unique name + device token

### DIFF
--- a/apps/backend/src/db/migrations/0007_lottery_unique_name_device_token.sql
+++ b/apps/backend/src/db/migrations/0007_lottery_unique_name_device_token.sql
@@ -1,0 +1,5 @@
+-- Add device_token column and unique constraint on name
+ALTER TABLE lottery_entries ADD COLUMN device_token TEXT;
+ALTER TABLE lottery_entries ADD CONSTRAINT lottery_entries_name_unique UNIQUE (name);
+-- Partial unique index: only enforce uniqueness when device_token is not null
+CREATE UNIQUE INDEX lottery_entries_device_token_idx ON lottery_entries (device_token) WHERE device_token IS NOT NULL;

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1747612800000,
       "tag": "0006_lottery_table_no",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1747699200000,
+      "tag": "0007_lottery_unique_name_device_token",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -29,9 +29,10 @@ export type SelectMatchmakingSubmission = typeof matchmakingSubmissions.$inferSe
 
 export const lotteryEntries = pgTable('lottery_entries', {
   id: serial('id').primaryKey(),
-  name: text('name').notNull(),
+  name: text('name').notNull().unique(),
   number: text('number').notNull().unique(),
   tableNo: text('table_no'),
+  deviceToken: text('device_token'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 });
 

--- a/apps/backend/src/lib/errors.ts
+++ b/apps/backend/src/lib/errors.ts
@@ -8,3 +8,13 @@ export function isUniqueViolation(error: unknown): boolean {
   const text = inspect(error, { depth: 8, getters: true });
   return /23505|unique constraint|duplicate key/i.test(text);
 }
+
+// Returns the violated constraint/index name, or null if not a unique violation.
+export function getUniqueConstraintName(error: unknown): string | null {
+  if (!isUniqueViolation(error)) return null;
+  const text = inspect(error, { depth: 8, getters: true });
+  const match = text.match(/constraint["\s]+([a-z0-9_]+)/i)
+    ?? text.match(/unique["\s]+constraint["\s"]+([a-z0-9_]+)/i)
+    ?? text.match(/index["\s"]+([a-z0-9_]+)/i);
+  return match?.[1] ?? null;
+}

--- a/apps/backend/src/routes/lottery.ts
+++ b/apps/backend/src/routes/lottery.ts
@@ -3,7 +3,7 @@ import { Effect } from 'effect';
 import { SqlClient } from '@effect/sql';
 import { dbRuntime } from '../db';
 import { requireServiceKey, requireModToken } from '../lib/auth';
-import { isUniqueViolation } from '../lib/errors';
+import { isUniqueViolation, getUniqueConstraintName } from '../lib/errors';
 
 const PRIZE_DIGITS: Record<number, number> = { 1: 6, 2: 3, 3: 3 };
 
@@ -22,13 +22,14 @@ export const lotteryRoutes = new Elysia()
       return { success: false, message: 'หมายเลขต้องมี 6 หลักเท่านั้น' };
     }
     const tableNo = body.table_no?.trim() || null;
+    const deviceToken = body.device_token?.trim() || null;
     try {
       const result = await dbRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{ id: number; name: string; number: string; table_no: string | null; created_at: string }>`
-            insert into lottery_entries (name, number, table_no)
-            values (${body.name.trim()}, ${num}, ${tableNo})
+            insert into lottery_entries (name, number, table_no, device_token)
+            values (${body.name.trim()}, ${num}, ${tableNo}, ${deviceToken})
             returning id, name, number, table_no, created_at
           `;
           return rows[0];
@@ -38,6 +39,13 @@ export const lotteryRoutes = new Elysia()
     } catch (error: unknown) {
       if (isUniqueViolation(error)) {
         set.status = 409;
+        const constraint = getUniqueConstraintName(error) ?? '';
+        if (constraint.includes('device_token')) {
+          return { success: false, message: 'คุณได้ส่งหมายเลขไปแล้ว ไม่สามารถส่งซ้ำได้' };
+        }
+        if (constraint.includes('name')) {
+          return { success: false, message: 'ชื่อนี้ถูกใช้ไปแล้ว กรุณาตรวจสอบชื่อของคุณ' };
+        }
         return { success: false, message: 'หมายเลขนี้ถูกใช้ไปแล้ว กรุณาเลือกหมายเลขอื่น' };
       }
       console.error('Failed to save lottery entry', error);
@@ -48,6 +56,7 @@ export const lotteryRoutes = new Elysia()
       name: t.String({ minLength: 1, maxLength: 120 }),
       number: t.String({ minLength: 1, maxLength: 6 }),
       table_no: t.Optional(t.String({ maxLength: 20 })),
+      device_token: t.Optional(t.String({ maxLength: 64 })),
     }),
   })
   .get('/api/lottery/numbers', async ({ headers, set }) => {

--- a/apps/frontend/src/views/LotteryView.vue
+++ b/apps/frontend/src/views/LotteryView.vue
@@ -9,6 +9,17 @@ const loading = ref(false)
 const success = ref<string | null>(null)
 const error = ref<string | null>(null)
 
+const DEVICE_TOKEN_KEY = 'lottery_device_token'
+
+function getOrCreateDeviceToken(): string {
+  let token = localStorage.getItem(DEVICE_TOKEN_KEY)
+  if (!token) {
+    token = crypto.randomUUID()
+    localStorage.setItem(DEVICE_TOKEN_KEY, token)
+  }
+  return token
+}
+
 const addDigit = (digit: number) => {
   if (number.value.length < 6 && !number.value.includes(digit.toString())) {
     number.value += digit.toString()
@@ -36,7 +47,12 @@ async function submit() {
     const res = await apiFetch('/api/lottery', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name.value.trim(), number: number.value.trim(), table_no: tableNo.value.trim() || undefined }),
+      body: JSON.stringify({
+        name: name.value.trim(),
+        number: number.value.trim(),
+        table_no: tableNo.value.trim() || undefined,
+        device_token: getOrCreateDeviceToken(),
+      }),
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok || !data?.success) throw new Error(data?.message || 'ส่งข้อมูลไม่สำเร็จ กรุณาลองใหม่อีกครั้ง')


### PR DESCRIPTION
## Summary
- Unique constraint on `name` column in `lottery_entries`
- `device_token` column with partial unique index (non-null only)
- Frontend generates UUID in localStorage, sends with each request
- Specific 409 error messages per violation type

## ⚠️ Manual DB migration required before this takes effect
Run `0007_lottery_unique_name_device_token.sql` on prod DB first. See README for instructions.

## Test plan
- [ ] Submit lottery → succeeds
- [ ] Submit again same device → "คุณได้ส่งหมายเลขไปแล้ว"
- [ ] Submit same name different device → "ชื่อนี้ถูกใช้ไปแล้ว"
- [ ] Submit same number → "หมายเลขนี้ถูกใช้ไปแล้ว"

🤖 Generated with [Claude Code](https://claude.com/claude-code)